### PR TITLE
#28: make sure only one device per user can be added

### DIFF
--- a/src/pad.c
+++ b/src/pad.c
@@ -59,7 +59,6 @@ static FILE *pusb_pad_open_device(t_pusb_options *opts,
 	if (!f)
 	{
 		log_debug("Cannot open device file: %s\n", strerror(errno));
-		log_debug("mode was: %s, device file was: %s/%s/%s.%s.pad\n", mode, mnt_point, opts->device_pad_directory, user, opts->hostname);
 		return (NULL);
 	}
 	return (f);

--- a/tests/can-actually-be-used/run-tests.sh
+++ b/tests/can-actually-be-used/run-tests.sh
@@ -9,4 +9,5 @@ rm -rf /home/`whoami`/.pamusb
 ./test-conf-detects-device.sh && \
 ./test-conf-adds-device.sh && \
 ./test-conf-adds-user.sh && \
+./test-conf-doesnt-add-user-twice.sh && \
 ./test-check-verify-created-config.sh

--- a/tests/can-actually-be-used/setup-dummyhcd.sh
+++ b/tests/can-actually-be-used/setup-dummyhcd.sh
@@ -7,4 +7,3 @@ git clone -b main https://github.com/0prichnik/dummy-hcd.git /tmp/src/dummy-hcd/
 cd /tmp/src/dummy-hcd/master/
 make update
 make dkms || cat /var/lib/dkms/dummy-hcd/0.1/build/make.log
-cat /var/lib/dkms/dummy-hcd/0.1/build/make.log

--- a/tests/can-actually-be-used/test-conf-doesnt-add-user-twice.sh
+++ b/tests/can-actually-be-used/test-conf-doesnt-add-user-twice.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+# @todo: this will fail if other devices are present. its missing a step to actually determine the number used internally
+# @todo: check if the numbering used in debconf is correct after all
+
+echo -e "Test:\t\t\tpamusb-conf doesn't add user(s) twice"
+echo -en "pamusb-conf output:\t" # to fake the unhideable python output as expected output :P
+sudo pamusb-conf --add-user=`whoami` --device=0 --yes | grep "already added" > /dev/null && echo -e "Result:\t\t\tPASSED!" || exit 1

--- a/tests/can-actually-be-used/test-conf-doesnt-add-user-twice.sh
+++ b/tests/can-actually-be-used/test-conf-doesnt-add-user-twice.sh
@@ -4,5 +4,4 @@
 # @todo: check if the numbering used in debconf is correct after all
 
 echo -e "Test:\t\t\tpamusb-conf doesn't add user(s) twice"
-echo -en "pamusb-conf output:\t" # to fake the unhideable python output as expected output :P
 sudo pamusb-conf --add-user=`whoami` --device=0 --yes | grep "already added" > /dev/null && echo -e "Result:\t\t\tPASSED!" || exit 1

--- a/tools/pamusb-conf
+++ b/tools/pamusb-conf
@@ -123,6 +123,13 @@ def addUser(options):
 		print('You must add a device (--add-device) before adding users')
 		sys.exit(1)
 
+	alreadyConfiguredUsers = doc.getElementsByTagName('user')
+	if len(alreadyConfiguredUsers) > 0:
+		for user in alreadyConfiguredUsers:
+			if user.getAttribute('id') == options['userName']:
+				print('This user is already added to the configuration, to edit it you need to do it manually currently - sorry.')
+				sys.exit(1)
+
 	devices = []
 	for device in devicesObj:
 		devices.append(device.getAttribute('id'))


### PR DESCRIPTION
This change introduces a check if the user to be added is already configured, if so: exit with error

Closes #28 