### PR TITLE
#23: Add python3-gi to debian package requirements

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,6 @@ Package: libpam-usb
 Architecture: any
 # Multi-Arch: same
 Pre-Depends: libpam-runtime (>= 1.0.1-6~), ${misc:Pre-Depends}
-Depends: ${shlibs:Depends}, ${misc:Depends}, python3, udisks2, gir1.2-udisks-2.0, libpam0g, libxml2, libglib2.0-0
+Depends: ${shlibs:Depends}, ${misc:Depends}, python3, python3-gi, udisks2, gir1.2-udisks-2.0, libpam0g, libxml2, libglib2.0-0
 Description: Adds auth over usb-stick to pam
  Provides a new pam module, pam_usb.so, that can be used in pam.d/common-auth


### PR DESCRIPTION
This fixes another missing dependency, for Debian minimal (truely, without Desktop)

Closes #23 (again)