### PR TITLE
#36: Use correct target lib dir on x64 machines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,14 @@
 DEBUG		:= no
 
 PREFIX		?= /usr
-LIBDIR		?= lib
+ARCH := $(shell uname -m)
+
+ifeq ($(ARCH), x86_64)
+	LIBDIR ?= lib/x86_64-linux-gnu
+endif
+ifeq ($(ARCH), i686)
+	LIBDIR ?= lib
+endif
 
 # compiler/linker options
 CC		:= gcc


### PR DESCRIPTION
Current libpam versions only look in the arch-native lib directory for modules. 

Till now we always targeted /usr/lib, even on x64. This is now fixed.

Closes #36 