### PR TITLE
#38: Fix Lintian error 'bad-distribution-in-changes-file'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ PAM_AUTH_UPDATE := pam-auth-update
 RM		:= rm
 INSTALL		:= install
 MKDIR		:= mkdir
-DEBUILD := debuild
+DEBUILD := debuild -b -uc -us --lintian-opts --profile debian
 
 ifeq (yes, ${DEBUG})
 	CFLAGS := ${CFLAGS} -ggdb
@@ -104,7 +104,7 @@ debchangelog :
 		git log --pretty=format:"  * %s (%an <%ae>)" --date=short 40b17fa..HEAD > changelog-for-deb
 
 deb : clean all
-	$(DEBUILD) -b -uc -us
+	$(DEBUILD)
 
 deb-sign : deb
 	debsign -S -k$(APT_SIGNING_KEY) `ls -t ../*.changes | head -1`

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-libpam-usb (0.7.1) focal; urgency=medium
+libpam-usb (0.7.1) unstable; urgency=medium
 
   * Added missing dependencies
   * Fix volume count detection in configure scripts
@@ -8,7 +8,7 @@ libpam-usb (0.7.1) focal; urgency=medium
 
  -- Tobias Bäumer <tobiasbaeumer@gmail.com>  Thu, 31 Dec 2020 11:52:34 +0200
 
-libpam-usb (0.7.0) focal; urgency=medium
+libpam-usb (0.7.0) unstable; urgency=medium
 
   * Re-release - Uses github.com/mcdope/pam_usb as source
   * Ported to Python 3
@@ -25,7 +25,7 @@ libpam-usb (0.7.0) focal; urgency=medium
 
  -- Tobias Bäumer <tobiasbaeumer@gmail.com>  Thu, 20 Aug 2020 10:22:34 +0200
 
-libpam-usb (0.6.0-5) artful; urgency=medium
+libpam-usb (0.6.0-5) unstable; urgency=medium
 
   * Initial release - Uses github.com/luka-n/pam_usb as source (0.5.0, ported to UDisks2)
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,7 +3,7 @@ Upstream-Name: libpam-usb
 Source: https://github.com/mcdope/pam_usb
 
 Files: *
-Copyright: 2003-2016 Andrea Luzzardi and contributers <scox@sig11.org>
+Copyright: 2003-2016 Andrea Luzzardi and contributors <scox@sig11.org>
 License: GPL-2
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This sets distribution field in changes file to "unstable", so Lintian doesn't report bad-distribution-in-changes-file anymore.

Closes #38 
Closes #42 