### PR TITLE
#8/#39: Rework deny_remote / remove unknown_pts_as_local

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+* 0.7.3
+- Reworked deny_remote option
+- Removed unknown_pts_as_local option (not needed anymore)
+
+* 0.7.2
+- Works with libpam >= 1.4.0 / installs to correct target directory
+- Fix Lintian error 'bad-distribution-in-changes-file' on non-Ubuntu
+- Fix spelling error in debian/copyright
+- Change default value for unknown_pts_as_local to false
+
 * 0.7.1
 - [Debian] Added missing dependencies
 - [Debian] Fix volume count detection in configure scripts for later versions of udisksctl

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ SRCS		:= src/conf.c \
 		   src/xpath.c \
 		   src/pad.c \
 		   src/volume.c \
+		   src/process.c \
 		   src/local.c \
 		   src/device.c
 OBJS		:= $(SRCS:.c=.o)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+libpam-usb (0.7.3) unstable; urgency=high
+
+  * Reworked deny_remote option
+  * Removed unknown_pts_as_local option (not needed anymore)
+
+ -- Tobias Bäumer <tobiasbaeumer@gmail.com>  Sat, 13 Feb 2021 22:23:34 +0100
+
 libpam-usb (0.7.2) unstable; urgency=high
 
   * Works with libpam >= 1.4.0 / installs to correct target directory

--- a/debian/copyright
+++ b/debian/copyright
@@ -43,3 +43,26 @@ License: GPL-2+
  .
  On Debian systems, the complete text of the GNU General
  Public License version 2 can be found in "/usr/share/common-licenses/GPL-2".
+ 
+Files: src/process.*
+Copyright:
+ - 2014, Florent Clairambault (@fclairamb)
+License: MIT
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ 

--- a/doc/CONFIGURATION
+++ b/doc/CONFIGURATION
@@ -42,7 +42,6 @@ The syntax is the following:
 | `color_log`            | Boolean | `true`              | Enable colored output                                            |
 | `one_time_pad`         | Boolean | `true`              | Enable the use of one time device-associated pad files           |
 | `deny_remote`          | Boolean | `true`              | Deny access from remote host (SSH)                               |
-| `unknown_pts_as_local` | Boolean | `false`             | Assume sessions from pseudo terminals to be local if not in utmp |
 | `probe_timeout`        | Time    | `10s`               | Time to wait for the volume to be detected                       |
 | `pad_expiration`       | Time    | `1h`                | Time between pad file regeneration                               |
 | `hostname`             | String  | Computer's hostname | Must be unique accross computers using the same device           |

--- a/doc/pam_usb.conf
+++ b/doc/pam_usb.conf
@@ -8,7 +8,6 @@ See http://www.pamusb.org/doc/configuring
 				<!-- Example:
 						<option name="debug">true</option>
 						<option name="deny_remote">true</option>
-						<option name="unknown_pts_as_local">false</option>
 				-->
 		</defaults>
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -51,8 +51,6 @@ static void pusb_conf_options_get_from(t_pusb_options *opts,
 			&(opts->probe_timeout));
 	pusb_xpath_get_bool_from(doc, from, "option[@name='deny_remote']",
 			&(opts->deny_remote));
-	pusb_xpath_get_bool_from(doc, from, "option[@name='unknown_pts_as_local']",
-			&(opts->unknown_pts_as_local));
 }
 
 static int pusb_conf_parse_options(t_pusb_options *opts,
@@ -150,7 +148,6 @@ int pusb_conf_init(t_pusb_options *opts)
 	opts->one_time_pad = 1;
 	opts->pad_expiration = 3600;
 	opts->deny_remote = 1;
-	opts->unknown_pts_as_local = 0;
 	return (1);
 }
 

--- a/src/conf.h
+++ b/src/conf.h
@@ -50,7 +50,6 @@ typedef struct		pusb_options
 	int				one_time_pad;
 	time_t			pad_expiration;
 	int				deny_remote;
-	int				unknown_pts_as_local;
 	char			hostname[64];
 	char			system_pad_directory[PATH_MAX];
 	char			device_pad_directory[PATH_MAX];

--- a/src/local.c
+++ b/src/local.c
@@ -18,7 +18,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
-#include <utmp.h>
 #include "log.h"
 #include "conf.h"
 #include "process.h"

--- a/src/process.c
+++ b/src/process.c
@@ -1,0 +1,55 @@
+/**
+ * Source: https://gist.github.com/fclairamb/a16a4237c46440bdb172
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "process.h"
+
+/**
+ * Get a process name from its PID.
+ * @param pid PID of the process
+ * @param name Name of the process
+ * 
+ * Source: http://stackoverflow.com/questions/15545341/process-name-from-its-pid-in-linux
+ */
+void get_process_name(const pid_t pid, char * name) {
+	char procfile[BUFSIZ];
+	sprintf(procfile, "/proc/%d/cmdline", pid);
+	FILE* f = fopen(procfile, "r");
+	if (f) {
+		size_t size;
+		size = fread(name, sizeof (char), sizeof (procfile), f);
+		if (size > 0) {
+			if ('\n' == name[size - 1])
+				name[size - 1] = '\0';
+		}
+		fclose(f);
+	}
+}
+
+/**
+ * Get the parent PID from a PID
+ * @param pid pid
+ * @param ppid parent process id
+ * 
+ * Note: init is 1 and it has a parent id of 0.
+ */
+void get_process_parent_id(const pid_t pid, pid_t * ppid) {
+	char buffer[BUFSIZ];
+	sprintf(buffer, "/proc/%d/stat", pid);
+	FILE* fp = fopen(buffer, "r");
+	if (fp) {
+		size_t size = fread(buffer, sizeof (char), sizeof (buffer), fp);
+		if (size > 0) {
+			// See: http://man7.org/linux/man-pages/man5/proc.5.html section /proc/[pid]/stat
+			strtok(buffer, " "); // (1) pid  %d
+			strtok(NULL, " "); // (2) comm  %s
+			strtok(NULL, " "); // (3) state  %c
+			char * s_ppid = strtok(NULL, " "); // (4) ppid  %d
+			*ppid = atoi(s_ppid);
+		}
+		fclose(fp);
+	}
+}

--- a/src/process.c
+++ b/src/process.c
@@ -1,8 +1,26 @@
 /**
  * Source: https://gist.github.com/fclairamb/a16a4237c46440bdb172
- * Original Author: Florent Clairambault (@fclairamb) [MIT licensed]
- *
  * Modifications: removed main(), added header file
+ * 
+ * Copyright 2014 Florent Clairambault (@fclairamb)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal 
+ * in the Software without restriction, including without limitation the rights 
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+ * copies of the Software, and to permit persons to whom the Software is 
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in 
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
  */
 
 #include <stdio.h>

--- a/src/process.c
+++ b/src/process.c
@@ -1,5 +1,8 @@
 /**
  * Source: https://gist.github.com/fclairamb/a16a4237c46440bdb172
+ * Original Author: Florent Clairambault (@fclairamb)
+ *
+ * Modifications: removed main(), added header file
  */
 
 #include <stdio.h>

--- a/src/process.c
+++ b/src/process.c
@@ -1,6 +1,6 @@
 /**
  * Source: https://gist.github.com/fclairamb/a16a4237c46440bdb172
- * Original Author: Florent Clairambault (@fclairamb)
+ * Original Author: Florent Clairambault (@fclairamb) [MIT licensed]
  *
  * Modifications: removed main(), added header file
  */

--- a/src/process.h
+++ b/src/process.h
@@ -1,0 +1,10 @@
+#ifndef PUSB_PROCESS_H_
+# define PUSB_PROCESS_H_
+
+#include <unistd.h>
+
+void get_process_name(const pid_t pid, char * name);
+
+void get_process_parent_id(const pid_t pid, pid_t * ppid);
+
+#endif /* !PUSB_PROCESS_H_ */

--- a/src/process.h
+++ b/src/process.h
@@ -1,3 +1,25 @@
+/**
+ * Copyright 2014 Florent Clairambault (@fclairamb)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal 
+ * in the Software without restriction, including without limitation the rights 
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+ * copies of the Software, and to permit persons to whom the Software is 
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in 
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+ * DEALINGS IN THE SOFTWARE.
+ */
+
 #ifndef PUSB_PROCESS_H_
 # define PUSB_PROCESS_H_
 


### PR DESCRIPTION
This reworks `deny_remote` handling to use process based checking. 

Instead of checking utmp and hoping there is an entry for the current session, which there often isn't for virtual terminals, we now check the chain of parent processes. If any parent process is sshd or telnetd we deny authentication.

This renders `unknown_pts_as_local` obsolete - removed.

Closes #8 (again)
See #39