### PR TITLE
Correct PKGBUILD to use correct repo

### DIFF
--- a/arch_linux/PKGBUILD
+++ b/arch_linux/PKGBUILD
@@ -19,7 +19,7 @@ source=(
   "pamusb-agent.service"
 )
 sha256sums=('SKIP'
-            'ec4a59f7ed86a7f0dd8e0cca8c8181343e1b69ab95a2d71b80530e0a5f6d07dc')
+            'f5875f0669b2638f36885c305d719072798b5097b15e6c94a8a852bb896bfc5c')
 
 pkgver() {
   cd $pkgname

--- a/arch_linux/PKGBUILD
+++ b/arch_linux/PKGBUILD
@@ -14,12 +14,12 @@ backup=(
   "etc/security/pam_usb.conf"
 )
 source=(
-  "git+https://github.com/Fincer/${pkgname}.git"
+  "git+https://github.com/mcdope/${pkgname}.git"
 #  "git+https://github.com/aluzzardi/${pkgname}.git"
   "pamusb-agent.service"
 )
 sha256sums=('SKIP'
-            'f5875f0669b2638f36885c305d719072798b5097b15e6c94a8a852bb896bfc5c')
+            'ec4a59f7ed86a7f0dd8e0cca8c8181343e1b69ab95a2d71b80530e0a5f6d07dc')
 
 pkgver() {
   cd $pkgname

--- a/doc/pamusb-check.1
+++ b/doc/pamusb-check.1
@@ -85,6 +85,7 @@ Shows debug messages.
 .B
 \fB--config\fP, \fB-c\fP
 Use the given configuration file (defaults to /etc/pamusb.conf).
+.B
 \fB--service\fP, \fB-s\fP Service name to be used for authentication (defaults to
 \fIpamusb-check\fP)
 .TP


### PR DESCRIPTION
I wanted to try to get this on my Arch desktop, and was having troubles. No clue why I checked, but the PKGBUILD was using a different fork. This will allow anyone deciding to use this to PKGBUILD in this repo to pull the right repo.