### PR TITLE
Allow Executing Complex Commands in pamusb-agent

### DIFF
--- a/tools/pamusb-agent
+++ b/tools/pamusb-agent
@@ -246,7 +246,7 @@ def userDeviceThread(user):
 				if len(l['cmd']) != 0:
 					for cmd in l['cmd']:
 						logger.info('Running "%s" (as %d:%d)' % (cmd, uid, gid))
-						subprocess.run(cmd.split(), env=l['env'], preexec_fn=runAs(uid, gid))
+						subprocess.run(['sh', '-c', cmd], env=l['env'], preexec_fn=runAs(uid, gid))
 
 				else:
 					logger.info('No commands defined for lock!')
@@ -269,7 +269,7 @@ def userDeviceThread(user):
 				if len(l['cmd']) != 0:
 					for cmd in l['cmd']:
 						logger.info('Running "%s" (as %d:%d)' % (cmd, uid, gid))
-						subprocess.run(cmd.split(), env=l['env'], preexec_fn=runAs(uid, gid))
+						subprocess.run(['sh', '-c', cmd], env=l['env'], preexec_fn=runAs(uid, gid))
 				
 				else:
 					logger.info('No commands defined for unlock!')


### PR DESCRIPTION
Previously, the splitting of cmd argument causes some limitations on complex commands
I've modified this to take the cmd argument as is, which allows Executing Commands containing:
- pipes | 
- redirect operator > 
- backticks ``
- dollar signs $
...

I've tested it with this complex command to lock the screen on systemd supported OS:
```xml
<cmd>loginctl lock-session `loginctl list-sessions | grep tty2 |  tr -s ' ' | cut -d' ' -f2`</cmd>
```