### PR TITLE
Identify ly as local login.

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -242,6 +242,7 @@ int pusb_local_login(t_pusb_options *opts, const char *user, const char *service
 		strcmp(service, "xdm") == 0 ||
 		strcmp(service, "lightdm") == 0 ||
 		strcmp(service, "sddm") == 0 ||
+		strcmp(service, "ly") == 0 ||
 		strcmp(service, "polkit-1") == 0
 	) {
 		log_debug("	Whitelisted request by %s detected, assuming local.\n", service);


### PR DESCRIPTION
[ly](https://github.com/nullgemm/ly) is a terminal-based login manager/display manager, so white-listing it as local.

Tested and worked on my machine, however at the 2nd login time, it gives an error:

```
(process:12375): GLib-GObject-WARNING **: 10:00:21.026: cannot register existing type 'UDisksClient'
(process:12375): GLib-GObject-CRITICAL **: 10:00:21.028: g_type_add_interface_static: assertion 'G_TYPE_IS_INSTANTIATABLE (instance_type)' failed
(process:12375): GLib-GObject-CRITICAL **: 10:00:21.028: g_type_add_interface_static: assertion 'G_TYPE_IS_INSTANTIATABLE (instance_type)' failed
(process:12375): GLib-CRITICAL **: 10:00:21.028: g_once_init_leave: assertion 'result != 0' failed
(process:12375): GLib-GIO-CRITICAL **: 10:00:21.028: g_initable_new_valist: assertion 'G_TYPE_IS_INITABLE (object_type)' failed
(process:12375): libudisks2-CRITICAL **: 10:00:21.028: udisks_client_get_object_manager: assertion 'UDISKS_IS_CLIENT (client)' failed
Job 1, 'ly' terminated by signal SIGSEGV (Address boundary error)
```