### PR TITLE
Fix type for argument to stat

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <dirent.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 #include "log.h"
 #include "conf.h"
 #include "process.h"
@@ -171,7 +172,7 @@ char *pusb_get_tty_by_xorg_display(const char *display, const char *user)
 char *pusb_get_tty_by_loginctl()
 {
 	struct stat sb;
-	if (stat("/usr/bin/loginctl", sb) != 0) {
+	if (stat("/usr/bin/loginctl", &sb) != 0) {
 		log_debug("		loginctl is not available, skipping\n");
 		return (0);
 	}


### PR DESCRIPTION
Currently, using loginctl to obtain the tty results in a segmentation fault because the second argument to `stat` should be a pointer (https://linux.die.net/man/2/stat).

Didn't come up as a compilation error because `<sys/stat.h>` wasn't being included, so I added that as well.