### PR TITLE
#115: Whitelist 'login' as local service

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -177,7 +177,7 @@ char *pusb_get_tty_by_loginctl()
 		return (0);
 	}
 
-    char loginctl_cmd[90] = "loginctl show-session $(awk '/tty/ {print $1}' <(loginctl)) -p TTY | awk -F= '{print $2}'";
+    char loginctl_cmd[BUFSIZ] = "loginctl show-session $(awk '/tty/ {print $1}' <(loginctl)) -p TTY | tail -1 | awk -F= '{print $2}'";
     char buf[BUFSIZ];
     FILE *fp;
 
@@ -243,9 +243,10 @@ int pusb_local_login(t_pusb_options *opts, const char *user, const char *service
 		strcmp(service, "xdm") == 0 ||
 		strcmp(service, "lightdm") == 0 ||
 		strcmp(service, "sddm") == 0 ||
-		strcmp(service, "polkit-1") == 0
+		strcmp(service, "polkit-1") == 0 ||
+		strcmp(service, "login") == 0 // @todo: see issue #115, if we continue the check past here we gonna close the session for some reason
 	) {
-		log_debug("	Whitelisted request by %s detected, assuming local.\n", service);
+		log_debug("Whitelisted request by %s detected, assuming local.\n", service);
 		local_request = 1;
 	}
 


### PR DESCRIPTION
This workarounds the problem from #115 by whitelisting tty logins as local

Closes #115