### PR TITLE
[Packaging] [Arch] Add docker based builds

### DIFF
--- a/.github/workflows/can-be-built-successfully.yml
+++ b/.github/workflows/can-be-built-successfully.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  jammy:
+  ubuntu-22.04:
 
     runs-on: ubuntu-22.04
 
@@ -17,15 +17,3 @@ jobs:
       run: sudo apt install libudisks2-dev libxml2-dev python-is-python3 libpam0g-dev pkg-config gir1.2-glib-2.0 libglib2.0-dev
     - name: make
       run: make
-
-  bionic:
-
-    runs-on: ubuntu-18.04
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install requirements
-      run: sudo apt install libudisks2-dev libxml2-dev python libpam0g-dev pkg-config gir1.2-glib-2.0 libglib2.0-dev
-    - name: make
-      run: make
-

--- a/.github/workflows/can-be-built-successfully.yml
+++ b/.github/workflows/can-be-built-successfully.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  ubuntu-22.04:
+  jammy:
 
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/package-with-docker-on-own-server.yml
+++ b/.github/workflows/package-with-docker-on-own-server.yml
@@ -1,4 +1,4 @@
-name: Packaging (deb, rpm)
+name: Packaging (deb, rpm, zst)
 
 on:
   pull_request:
@@ -140,7 +140,7 @@ jobs:
         TEST_RUNNER_HOST: ${{ secrets.TEST_RUNNER_HOST }}
         TEST_RUNNER_USER: ${{ secrets.TEST_RUNNER_USER }}
         TEST_RUNNER_PASS: ${{ secrets.TEST_RUNNER_PASS }}
-      run: sshpass -p "$TEST_RUNNER_PASS" ssh -o StrictHostKeyChecking=no $TEST_RUNNER_USER@$TEST_RUNNER_HOST "rm -rf ~/pam_usb_arch_$GITHUB_RUN_ID; mkdir ~/pam_usb_arch_$GITHUB_RUN_ID; cd ~/pam_usb_arch_$GITHUB_RUN_ID && git clone https://github.com/mcdope/pam_usb.git ."
+      run: sshpass -p "$TEST_RUNNER_PASS" ssh -o StrictHostKeyChecking=no $TEST_RUNNER_USER@$TEST_RUNNER_HOST "rm -rf ~/pam_usb_arch_$GITHUB_RUN_ID; mkdir ~/pam_usb_arch_$GITHUB_RUN_ID; chmod -R 0777 ~/pam_usb_arch_$GITHUB_RUN_ID; cd ~/pam_usb_arch_$GITHUB_RUN_ID && git clone https://github.com/mcdope/pam_usb.git ."
     - name: git fetch --all
       env:
         TEST_RUNNER_HOST: ${{ secrets.TEST_RUNNER_HOST }}

--- a/.github/workflows/package-with-docker-on-own-server.yml
+++ b/.github/workflows/package-with-docker-on-own-server.yml
@@ -140,7 +140,7 @@ jobs:
         TEST_RUNNER_HOST: ${{ secrets.TEST_RUNNER_HOST }}
         TEST_RUNNER_USER: ${{ secrets.TEST_RUNNER_USER }}
         TEST_RUNNER_PASS: ${{ secrets.TEST_RUNNER_PASS }}
-      run: sshpass -p "$TEST_RUNNER_PASS" ssh -o StrictHostKeyChecking=no $TEST_RUNNER_USER@$TEST_RUNNER_HOST "rm -rf ~/pam_usb_arch_$GITHUB_RUN_ID; mkdir ~/pam_usb_arch_$GITHUB_RUN_ID; chmod -R 0777 ~/pam_usb_arch_$GITHUB_RUN_ID; cd ~/pam_usb_arch_$GITHUB_RUN_ID && git clone https://github.com/mcdope/pam_usb.git ."
+      run: sshpass -p "$TEST_RUNNER_PASS" ssh -o StrictHostKeyChecking=no $TEST_RUNNER_USER@$TEST_RUNNER_HOST "rm -rf ~/pam_usb_arch_$GITHUB_RUN_ID; mkdir ~/pam_usb_arch_$GITHUB_RUN_ID; cd ~/pam_usb_arch_$GITHUB_RUN_ID && git clone https://github.com/mcdope/pam_usb.git . && chmod -R 0777 ~/pam_usb_arch_$GITHUB_RUN_ID/arch_linux"
     - name: git fetch --all
       env:
         TEST_RUNNER_HOST: ${{ secrets.TEST_RUNNER_HOST }}

--- a/.github/workflows/package-with-docker-on-own-server.yml
+++ b/.github/workflows/package-with-docker-on-own-server.yml
@@ -140,7 +140,7 @@ jobs:
         TEST_RUNNER_HOST: ${{ secrets.TEST_RUNNER_HOST }}
         TEST_RUNNER_USER: ${{ secrets.TEST_RUNNER_USER }}
         TEST_RUNNER_PASS: ${{ secrets.TEST_RUNNER_PASS }}
-      run: sshpass -p "$TEST_RUNNER_PASS" ssh -o StrictHostKeyChecking=no $TEST_RUNNER_USER@$TEST_RUNNER_HOST "rm -rf ~/pam_usb_arch_$GITHUB_RUN_ID; mkdir ~/pam_usb_arch_$GITHUB_RUN_ID; cd ~/pam_usb_arch_$GITHUB_RUN_ID && git clone https://github.com/mcdope/pam_usb.git . && chmod -R 0777 ~/pam_usb_arch_$GITHUB_RUN_ID/arch_linux"
+      run: sshpass -p "$TEST_RUNNER_PASS" ssh -o StrictHostKeyChecking=no $TEST_RUNNER_USER@$TEST_RUNNER_HOST "rm -rf ~/pam_usb_arch_$GITHUB_RUN_ID; mkdir ~/pam_usb_arch_$GITHUB_RUN_ID; cd ~/pam_usb_arch_$GITHUB_RUN_ID && git clone https://github.com/mcdope/pam_usb.git . && chmod -R 0777 ~/pam_usb_arch_$GITHUB_RUN_ID"
     - name: git fetch --all
       env:
         TEST_RUNNER_HOST: ${{ secrets.TEST_RUNNER_HOST }}

--- a/.github/workflows/package-with-docker-on-own-server.yml
+++ b/.github/workflows/package-with-docker-on-own-server.yml
@@ -125,3 +125,62 @@ jobs:
         TEST_RUNNER_USER: ${{ secrets.TEST_RUNNER_USER }}
         TEST_RUNNER_PASS: ${{ secrets.TEST_RUNNER_PASS }}
       run: sshpass -p "$TEST_RUNNER_PASS" ssh -o StrictHostKeyChecking=no $TEST_RUNNER_USER@$TEST_RUNNER_HOST "rm -rf ~/pam_usb_rpm_$GITHUB_RUN_ID"
+
+  Arch:
+
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Install local requirements
+      run: sudo apt install sshpass
+    - name: FURTHER STEPS EXECUTED ON CONFIGURED RUNNER
+      run: echo 0
+    - name: git clone
+      env:
+        TEST_RUNNER_HOST: ${{ secrets.TEST_RUNNER_HOST }}
+        TEST_RUNNER_USER: ${{ secrets.TEST_RUNNER_USER }}
+        TEST_RUNNER_PASS: ${{ secrets.TEST_RUNNER_PASS }}
+      run: sshpass -p "$TEST_RUNNER_PASS" ssh -o StrictHostKeyChecking=no $TEST_RUNNER_USER@$TEST_RUNNER_HOST "rm -rf ~/pam_usb_arch_$GITHUB_RUN_ID; mkdir ~/pam_usb_arch_$GITHUB_RUN_ID; cd ~/pam_usb_arch_$GITHUB_RUN_ID && git clone https://github.com/mcdope/pam_usb.git ."
+    - name: git fetch --all
+      env:
+        TEST_RUNNER_HOST: ${{ secrets.TEST_RUNNER_HOST }}
+        TEST_RUNNER_USER: ${{ secrets.TEST_RUNNER_USER }}
+        TEST_RUNNER_PASS: ${{ secrets.TEST_RUNNER_PASS }}
+      run: sshpass -p "$TEST_RUNNER_PASS" ssh -o StrictHostKeyChecking=no $TEST_RUNNER_USER@$TEST_RUNNER_HOST "cd ~/pam_usb_arch_$GITHUB_RUN_ID && git fetch --all"
+    - name: git reset --hard
+      env:
+        TEST_RUNNER_HOST: ${{ secrets.TEST_RUNNER_HOST }}
+        TEST_RUNNER_USER: ${{ secrets.TEST_RUNNER_USER }}
+        TEST_RUNNER_PASS: ${{ secrets.TEST_RUNNER_PASS }}
+      run: sshpass -p "$TEST_RUNNER_PASS" ssh -o StrictHostKeyChecking=no $TEST_RUNNER_USER@$TEST_RUNNER_HOST "cd ~/pam_usb_arch_$GITHUB_RUN_ID && git reset --hard"
+    - name: git switch -f
+      env:
+        TEST_RUNNER_HOST: ${{ secrets.TEST_RUNNER_HOST }}
+        TEST_RUNNER_USER: ${{ secrets.TEST_RUNNER_USER }}
+        TEST_RUNNER_PASS: ${{ secrets.TEST_RUNNER_PASS }}
+        REF_TO_CHECKOUT: ${{ github.head_ref }}
+      run: sshpass -p "$TEST_RUNNER_PASS" ssh -o StrictHostKeyChecking=no $TEST_RUNNER_USER@$TEST_RUNNER_HOST "cd ~/pam_usb_arch_$GITHUB_RUN_ID && git switch -f $REF_TO_CHECKOUT || git switch -f master"
+    - name: git pull
+      env:
+        TEST_RUNNER_HOST: ${{ secrets.TEST_RUNNER_HOST }}
+        TEST_RUNNER_USER: ${{ secrets.TEST_RUNNER_USER }}
+        TEST_RUNNER_PASS: ${{ secrets.TEST_RUNNER_PASS }}
+      run: sshpass -p "$TEST_RUNNER_PASS" ssh -o StrictHostKeyChecking=no $TEST_RUNNER_USER@$TEST_RUNNER_HOST "cd ~/pam_usb_arch_$GITHUB_RUN_ID && git pull"
+    - name: Generate build environment
+      env:
+        TEST_RUNNER_HOST: ${{ secrets.TEST_RUNNER_HOST }}
+        TEST_RUNNER_USER: ${{ secrets.TEST_RUNNER_USER }}
+        TEST_RUNNER_PASS: ${{ secrets.TEST_RUNNER_PASS }}
+      run: sshpass -p "$TEST_RUNNER_PASS" ssh -o StrictHostKeyChecking=no $TEST_RUNNER_USER@$TEST_RUNNER_HOST "cd ~/pam_usb_arch_$GITHUB_RUN_ID && make buildenv-arch"
+    - name: Build package
+      env:
+        TEST_RUNNER_HOST: ${{ secrets.TEST_RUNNER_HOST }}
+        TEST_RUNNER_USER: ${{ secrets.TEST_RUNNER_USER }}
+        TEST_RUNNER_PASS: ${{ secrets.TEST_RUNNER_PASS }}
+      run: sshpass -p "$TEST_RUNNER_PASS" ssh -o StrictHostKeyChecking=no $TEST_RUNNER_USER@$TEST_RUNNER_HOST "cd ~/pam_usb_arch_$GITHUB_RUN_ID && make build-arch"
+    - name: Cleanup
+      env:
+        TEST_RUNNER_HOST: ${{ secrets.TEST_RUNNER_HOST }}
+        TEST_RUNNER_USER: ${{ secrets.TEST_RUNNER_USER }}
+        TEST_RUNNER_PASS: ${{ secrets.TEST_RUNNER_PASS }}
+      run: sshpass -p "$TEST_RUNNER_PASS" ssh -o StrictHostKeyChecking=no $TEST_RUNNER_USER@$TEST_RUNNER_HOST "rm -rf ~/pam_usb_arch_$GITHUB_RUN_ID"

--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -1,0 +1,7 @@
+FROM archlinux:latest
+ENV TERM=xterm
+WORKDIR /usr/local/src/pam_usb
+
+RUN useradd -m builduser
+RUN pacman --noconfirm -Syu
+RUN pacman --noconfirm -S sudo git pkgconf gcc make patch pam dbus python python-dbus python-lxml python-gobject udisks2 base-devel pacman-contrib

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ build-arch : buildenv-arch
 		-v`pwd`/.build:/usr/local/src \
 		-v`pwd`:/usr/local/src/pam_usb \
 		--rm mcdope/pam_usb-arch-build \
-		sh -c "chown -R builduser:builduser . && cd arch_linux && sudo -u builduser updpkgsums && sudo -u builduser makepkg && cd .. && chown -R $(UID):$(GID) ."
+		sh -c "chown -R builduser:builduser . && cd arch_linux && sudo -u builduser makepkg && cd .. && chown -R $(UID):$(GID) ."
 	yes | cp -rf arch_linux/*.zst .build
 	rm -rf arch_linux/src arch_linux/pkg arch_linux/pamusb.tar.gz arch_linux/*.zst
 	

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ debchangelog :
 		git log --pretty=format:"  * %s (%an <%ae>)" --date=short 40b17fa..HEAD > changelog-for-deb
 
 builddir :
-	mkdir -p .build
+	mkdir -p .build > /dev/null 2>&1 || echo 0
 
 deb : clean builddir
 	$(DEBUILD)

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ build-debian : buildenv-debian
 		-v`pwd`/.build:/usr/local/src \
 		-v`pwd`:/usr/local/src/pam_usb \
 		--rm mcdope/pam_usb-ubuntu-build \
-		sh -c "make deb && chown -R $(UID):$(GID) .build/libpam-usb* debian"
+		sh -c "make deb && chown -R $(UID):$(GID) .build debian"
 
 build-fedora : buildenv-fedora
 	$(DOCKER) run -i \

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ build-fedora : buildenv-fedora
 		-v`pwd`/.build:/usr/local/src \
 		-v`pwd`:/usr/local/src/pam_usb \
 		--rm mcdope/pam_usb-fedora-build \
-		sh -c "make rpm && chown $(UID):$(GID) ./.build/pam_usb* && chown -R $(UID):$(GID) .build/pam_usb* fedora"
+		sh -c "make rpm && chown -R $(UID):$(GID) .build fedora"
 
 build-arch : buildenv-arch
 	$(DOCKER) run -i \

--- a/Makefile
+++ b/Makefile
@@ -127,15 +127,16 @@ changelog :
 debchangelog : 
 		git log --pretty=format:"  * %s (%an <%ae>)" --date=short 40b17fa..HEAD > changelog-for-deb
 
-deb : clean
+builddir :
 	mkdir -p .build
+
+deb : clean builddir
 	$(DEBUILD)
 
 deb-sign : build-debian
 	debsign -S -k$(APT_SIGNING_KEY) `ls -t .build/*.changes | head -1`
 
-rpm : clean
-	mkdir -p .build
+rpm : clean builddir
 	$(RPMBUILD)
 	yes | cp -rf fedora/RPMS/$(ARCH)/*.rpm .build
 
@@ -145,8 +146,7 @@ rpm-sign: build-fedora
 rpm-lint: build-fedora
 	rpmlint `ls -t .build/*.rpm | head -1`
 
-zst: clean
-	mkdir -p .build
+zst: clean builddir
 	rm -f arch_linux/*.zst ../pamusb.tar.gz
 	tar --exclude="arch_linux" --exclude=".build" --exclude=".idea" --exclude=".vscode" --exclude="fedora" --exclude="tests" --exclude=".github" -zcvf ../pamusb.tar.gz . 
 	mv ../pamusb.tar.gz arch_linux/pamusb.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ build-arch : buildenv-arch
 		-v`pwd`/.build:/usr/local/src \
 		-v`pwd`:/usr/local/src/pam_usb \
 		--rm mcdope/pam_usb-arch-build \
-		sh -c "cd arch_linux && sudo -u builduser updpkgsums && sudo -u builduser makepkg"
+		sh -c "chown -R builduser:builduser . && cd arch_linux && sudo -u builduser updpkgsums && sudo -u builduser makepkg && cd .. && chown -R $(UID):$(GID) ."
 	yes | cp -rf arch_linux/*.zst .build
 	rm -rf arch_linux/src arch_linux/pkg arch_linux/pamusb.tar.gz arch_linux/*.zst
 	

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ build-arch : buildenv-arch
 		-v`pwd`/.build:/usr/local/src \
 		-v`pwd`:/usr/local/src/pam_usb \
 		--rm mcdope/pam_usb-arch-build \
-		sh -c "cd arch_linux && updpkgsums && sudo -u builduser makepkg"
+		sh -c "cd arch_linux && sudo -u builduser updpkgsums && sudo -u builduser makepkg"
 	yes | cp -rf arch_linux/*.zst .build
 	rm -rf arch_linux/src arch_linux/pkg arch_linux/pamusb.tar.gz arch_linux/*.zst
 	

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ build-arch : buildenv-arch
 		-v`pwd`/.build:/usr/local/src \
 		-v`pwd`:/usr/local/src/pam_usb \
 		--rm mcdope/pam_usb-arch-build \
-		sh -c "cd arch_linux && sudo -u builduser updpkgsums && sudo -u builduser makepkg"
+		sh -c "cd arch_linux && updpkgsums && sudo -u builduser makepkg"
 	yes | cp -rf arch_linux/*.zst .build
 	rm -rf arch_linux/src arch_linux/pkg arch_linux/pamusb.tar.gz arch_linux/*.zst
 	

--- a/arch_linux/PKGBUILD
+++ b/arch_linux/PKGBUILD
@@ -1,7 +1,7 @@
 # Created by: Pekka Helenius <fincer89 [at] hotmail [dot] com>
 
 pkgname=pam_usb
-pkgver=496.0.8.2_203facc
+pkgver=497.0.8.2_84692de
 pkgrel=1
 pkgdesc='Hardware authentication for Linux using ordinary USB Flash Drives.'
 arch=('x86_64')

--- a/arch_linux/PKGBUILD
+++ b/arch_linux/PKGBUILD
@@ -1,7 +1,7 @@
 # Created by: Pekka Helenius <fincer89 [at] hotmail [dot] com>
 
 pkgname=pam_usb
-pkgver=502.0.8.2_8c618f9
+pkgver=0.8.2.29
 pkgrel=1
 pkgdesc='Hardware authentication for Linux using ordinary USB Flash Drives.'
 arch=('x86_64')
@@ -22,7 +22,7 @@ sha256sums=('SKIP'
 
 pkgver() {
   cd ..
-  echo $(git rev-list --count HEAD).$(git for-each-ref --sort=creatordate --format '%(tag)' refs/tags | tail -n 1)_$(git rev-parse --short HEAD)
+  echo $(git for-each-ref --sort=creatordate --format '%(tag)' refs/tags | tail -n 1).$(git rev-list --count $(git for-each-ref --sort=creatordate --format '%(tag)' refs/tags | tail -n 1)..HEAD)
   cd $OLDPWD
 }
 

--- a/arch_linux/PKGBUILD
+++ b/arch_linux/PKGBUILD
@@ -1,11 +1,11 @@
 # Maintainer: Pekka Helenius <fincer89 [at] hotmail [dot] com>
 
 pkgname=pam_usb
-pkgver=270.96e4232
+pkgver=485.f472205
 pkgrel=1
 pkgdesc='Hardware authentication for Linux using ordinary USB Flash Drives.'
-arch=('any')
-url='http://www.pamusb.org/'
+arch=('x86_64')
+url='https://github.com/mcdope/pam_usb'
 license=('GPLv2')
 depends=('pam' 'dbus' 'python' 'python-dbus' 'python-lxml' 'python-gobject' 'udisks2')
 makedepends=('git' 'pkgconf' 'gcc' 'make' 'patch')
@@ -14,29 +14,23 @@ backup=(
   "etc/security/pam_usb.conf"
 )
 source=(
-  "git+https://github.com/mcdope/${pkgname}.git"
-#  "git+https://github.com/aluzzardi/${pkgname}.git"
+  "pamusb.tar.gz"
   "pamusb-agent.service"
 )
-sha256sums=('SKIP'
+sha256sums=('757178aeafffc771a460dee9eac66edddef4d36a0c822f6c2ac058ac49360a0c'
             'f5875f0669b2638f36885c305d719072798b5097b15e6c94a8a852bb896bfc5c')
 
 pkgver() {
-  cd $pkgname
-  if [[ $(git describe) ]]; then
-    git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
-  else
+  cd ..
+  #if [[ $(git describe) ]]; then
+  #  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
+  #else
     echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
-  fi
-}
-
-build() {
-  cd $pkgname
-  make all
+  #fi
+  cd $OLDPWD
 }
 
 package() {
-  cd $pkgname
   make DESTDIR=${pkgdir} PAM_USB_DEST=${pkgdir}/usr/lib/security install
   chmod 0700 ${pkgdir}/usr/bin/pamusb-agent
   install -Dt ${pkgdir}/usr/lib/systemd/system -m0644 ../pamusb-agent.service

--- a/arch_linux/PKGBUILD
+++ b/arch_linux/PKGBUILD
@@ -1,7 +1,7 @@
 # Created by: Pekka Helenius <fincer89 [at] hotmail [dot] com>
 
 pkgname=pam_usb
-pkgver=498.0.8.2_3f33636
+pkgver=501.0.8.2_5bac39f
 pkgrel=1
 pkgdesc='Hardware authentication for Linux using ordinary USB Flash Drives.'
 arch=('x86_64')

--- a/arch_linux/PKGBUILD
+++ b/arch_linux/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Pekka Helenius <fincer89 [at] hotmail [dot] com>
 
 pkgname=pam_usb
-pkgver=494.00e115c
+pkgver=495.570a89f
 pkgrel=1
 pkgdesc='Hardware authentication for Linux using ordinary USB Flash Drives.'
 arch=('x86_64')
@@ -17,7 +17,7 @@ source=(
   "pamusb.tar.gz"
   "pamusb-agent.service"
 )
-sha256sums=('316c17c27eec5b90b3acd25cdf2846aa1cb26b2734eddcf7ae7accaf26eb8b2e'
+sha256sums=('SKIP'
             'f5875f0669b2638f36885c305d719072798b5097b15e6c94a8a852bb896bfc5c')
 
 pkgver() {

--- a/arch_linux/PKGBUILD
+++ b/arch_linux/PKGBUILD
@@ -1,7 +1,7 @@
 # Created by: Pekka Helenius <fincer89 [at] hotmail [dot] com>
 
 pkgname=pam_usb
-pkgver=0.8.2.29
+pkgver=0.8.2.32
 pkgrel=1
 pkgdesc='Hardware authentication for Linux using ordinary USB Flash Drives.'
 arch=('x86_64')

--- a/arch_linux/PKGBUILD
+++ b/arch_linux/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Pekka Helenius <fincer89 [at] hotmail [dot] com>
 
 pkgname=pam_usb
-pkgver=485.f472205
+pkgver=494.00e115c
 pkgrel=1
 pkgdesc='Hardware authentication for Linux using ordinary USB Flash Drives.'
 arch=('x86_64')
@@ -17,7 +17,7 @@ source=(
   "pamusb.tar.gz"
   "pamusb-agent.service"
 )
-sha256sums=('757178aeafffc771a460dee9eac66edddef4d36a0c822f6c2ac058ac49360a0c'
+sha256sums=('316c17c27eec5b90b3acd25cdf2846aa1cb26b2734eddcf7ae7accaf26eb8b2e'
             'f5875f0669b2638f36885c305d719072798b5097b15e6c94a8a852bb896bfc5c')
 
 pkgver() {

--- a/arch_linux/PKGBUILD
+++ b/arch_linux/PKGBUILD
@@ -1,7 +1,7 @@
 # Created by: Pekka Helenius <fincer89 [at] hotmail [dot] com>
 
 pkgname=pam_usb
-pkgver=501.0.8.2_5bac39f
+pkgver=502.0.8.2_8c618f9
 pkgrel=1
 pkgdesc='Hardware authentication for Linux using ordinary USB Flash Drives.'
 arch=('x86_64')
@@ -28,6 +28,5 @@ pkgver() {
 
 package() {
   make DESTDIR=${pkgdir} PAM_USB_DEST=${pkgdir}/usr/lib/security install
-  chmod 0700 ${pkgdir}/usr/bin/pamusb-agent
   install -Dt ${pkgdir}/usr/lib/systemd/system -m0644 ../pamusb-agent.service
 }

--- a/arch_linux/PKGBUILD
+++ b/arch_linux/PKGBUILD
@@ -1,7 +1,7 @@
-# Maintainer: Pekka Helenius <fincer89 [at] hotmail [dot] com>
+# Created by: Pekka Helenius <fincer89 [at] hotmail [dot] com>
 
 pkgname=pam_usb
-pkgver=495.570a89f
+pkgver=496.0.8.2_203facc
 pkgrel=1
 pkgdesc='Hardware authentication for Linux using ordinary USB Flash Drives.'
 arch=('x86_64')
@@ -22,11 +22,7 @@ sha256sums=('SKIP'
 
 pkgver() {
   cd ..
-  #if [[ $(git describe) ]]; then
-  #  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g'
-  #else
-    echo $(git rev-list --count HEAD).$(git rev-parse --short HEAD)
-  #fi
+  echo $(git rev-list --count HEAD).$(git for-each-ref --sort=creatordate --format '%(tag)' refs/tags | tail -n 1)_$(git rev-parse --short HEAD)
   cd $OLDPWD
 }
 

--- a/arch_linux/PKGBUILD
+++ b/arch_linux/PKGBUILD
@@ -14,6 +14,8 @@ backup=(
   "etc/security/pam_usb.conf"
 )
 source=(
+  # for build from git: uncomment next line, comment the line after
+  # "git+https://github.com/mcdope/pam_usb.git"
   "pamusb.tar.gz"
   "pamusb-agent.service"
 )

--- a/arch_linux/PKGBUILD
+++ b/arch_linux/PKGBUILD
@@ -1,7 +1,7 @@
 # Created by: Pekka Helenius <fincer89 [at] hotmail [dot] com>
 
 pkgname=pam_usb
-pkgver=497.0.8.2_84692de
+pkgver=498.0.8.2_3f33636
 pkgrel=1
 pkgdesc='Hardware authentication for Linux using ordinary USB Flash Drives.'
 arch=('x86_64')


### PR DESCRIPTION
- Adds docker based build environment for Arch
- Adds make zst target
- Adds make target for docker based arch build
- Updates PKGBUILD
- Change arch versioning to $version.$countOfCommitsOnTop

Guess this could break using the PKGBUILD file for AUR since it now refers to a local tgz created by the make target. Feel free to fork if needed but I also left the git part in, just comment one line and uncomment another...