### PR TITLE
#188: Fix stupid bug while shortening DISPLAY with screen identifier

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -302,7 +302,7 @@ int pusb_local_login(t_pusb_options *opts, const char *user, const char *service
 			log_debug("	DISPLAY contains screen, truncating...\n");
 			char display_tmp[sizeof(display)];
 			snprintf(display_tmp, sizeof(display) - 2, "%s", display);
-			snprintf(display, strnlen(display_tmp, sizeof(display_tmp)), "%s", display_tmp);
+			snprintf(display, strnlen(display_tmp, (sizeof(display_tmp)+1))-1, "%s", display_tmp);
 		}
 
 		local_request = pusb_is_tty_local((char *) display);


### PR DESCRIPTION
Closes #188 