### PR TITLE
#184: Refactor whitelist

### DIFF
--- a/doc/pam_usb.conf
+++ b/doc/pam_usb.conf
@@ -77,5 +77,26 @@ See https://github.com/mcdope/pam_usb/wiki/Configuration
 						<option name="quiet">true</option>
 				</service>
 				-->
+
+				<!--
+					Default whitelist for "deny_remote".
+
+					These services are whitelisted because either
+						a) they are graphical login managers and we assume these be available only locally
+						b) they are authorization agents afters successful authentication.
+
+					Template:
+						<service id=""><option name="deny_remote">false</option></service>
+				-->
+				<service id="pamusb-agent"><option name="deny_remote">false</option></service>
+				<service id="gdm-password"><option name="deny_remote">false</option></service>
+				<service id="xdm"><option name="deny_remote">false</option></service>
+				<service id="lxdm"><option name="deny_remote">false</option></service>
+				<service id="xscreensaver"><option name="deny_remote">false</option></service>
+				<service id="lightdm"><option name="deny_remote">false</option></service>
+				<service id="sddm"><option name="deny_remote">false</option></service>
+				<service id="polkit-1"><option name="deny_remote">false</option></service>
+				<service id="kde"><option name="deny_remote">false</option></service>
+				<service id="login"><option name="deny_remote">false</option></service>
 		</services>
 </configuration>

--- a/src/local.c
+++ b/src/local.c
@@ -252,26 +252,6 @@ int pusb_local_login(t_pusb_options *opts, const char *user, const char *service
 		}
 	}
 
-	/**
-	 * These services are whitelisted because either a) they are graphical login managers and we assume these
-	 * to be available only locally or b) they are authorization agents afters successful authentication.
-	 */
-	if (strcmp(service, "pamusb-agent") == 0 ||
-		strcmp(service, "gdm-password") == 0 ||
-		strcmp(service, "xdm") == 0 ||
-		strcmp(service, "lxdm") == 0 ||
-		strcmp(service, "xscreensaver") == 0 ||
-		strcmp(service, "lightdm") == 0 ||
-		strcmp(service, "sddm") == 0 ||
-		strcmp(service, "polkit-1") == 0 ||
-		strcmp(service, "kde") == 0 || // KDE uses this for klockscreen
-		strcmp(service, "login") == 0 // @todo: see issue #115, if we continue the check past here we gonna close the session for some reason
-	) 
-	{
-		log_debug("Whitelisted request by %s detected, assuming local.\n", service);
-		local_request = 1;
-	}
-
 	const char *session_tty;
 	char *display = getenv("DISPLAY");
 


### PR DESCRIPTION
This replaces the hardcoded whitelist in `local.c` with a config based one

Closes #184 