### PR TITLE
#187: [Tools] Add experimental pinentry application

### DIFF
--- a/tools/pamusb-pinentry
+++ b/tools/pamusb-pinentry
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+import os
+import subprocess
+import getpass
+from dotenv import load_dotenv
+load_dotenv("~/.pamusb-pinentry.env")
+
+pinentryPassword = os.getenv('PINENTRY_PASSWORD')
+fallbackPinentryApp = os.getenv('PINENTRY_FALLBACK_APP')
+
+isAuthenticated = subprocess.run(["pamusb-check", getpass.getuser()], capture_output=True)
+if (isAuthenticated.returncode == 0):
+    print("OK Pleased to meet you")
+    while True:
+        line = input().split()
+        if line[0] == "GETPIN":
+            print("D %s" % pinentryPassword)
+        elif line[0] == "BYE":
+            exit()
+        print("OK")
+else:
+    subprocess.run(fallbackPinentryApp)


### PR DESCRIPTION
This adds an experimental pinentry application. 

Requirements:
[ ] File `~/.pamusb-pinentry.env`, containing the following:
    [ ] `PINENTRY_PASSWORD=yourGpgKeyPassword`
    [ ] `PINENTRY_FALLBACK_APP=/path/to/fallback/pinentry` (eg `/usr/bin/pinentry-gnome3` or whatever you're using right now)
[ ] Configure GPG to use this application by setting it in `~/.gnupg/gpg-agent.conf`. To do so add `pinentry-program /path/to/pamusb-pinentry`

Note: This MR is work-in-progress