### PR TITLE
add check for VSCode remote tunnel

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -305,8 +305,10 @@ int pusb_local_login(t_pusb_options *opts, const char *user, const char *service
 
 		previous_pid = pid;
 		pusb_get_process_parent_id(pid, & pid);
-		if (strstr(name, "sshd") != NULL || strstr(name, "telnetd") != NULL) 
-		{
+		if (strstr(name, "sshd") != NULL
+			|| strstr(name, "telnetd") != NULL
+			|| (strstr(name, "code") != NULL && strstr(name, "tunnel") != NULL)
+		) {
 			log_error("One of the parent processes found to be a remote access daemon, denying.\n");
 			return (0);
 		}


### PR DESCRIPTION
In the VSCode Microsft distributed version you can run it "remotely". Like you start the IDE as a server-only at one PC and access it through Microsoft servers and its authentication on another PC, and inside the IDE you can access an integrated terminal that is running in the remote PC. And when I was using sudo for some commands the pam_usb checked for my puggled device and authorized it.

This is caused by VSCode not registering it's sesssion(s) in utmp.

Reference here: https://code.visualstudio.com/docs/remote/tunnels