### PR TITLE
Potential fix for code scanning alert no. 231: Redundant null check due to previous dereference

### DIFF
--- a/src/volume.c
+++ b/src/volume.c
@@ -127,10 +127,14 @@ static t_pusb_volume *pusb_volume_probe(t_pusb_options *opts, UDisksClient *udis
 				volume->mount_point = NULL;
 
 				mount_points = udisks_filesystem_get_mount_points(volume->filesystem);
-				log_debug("Found mount points: %s\n", *mount_points);
 				if (mount_points && *mount_points)
 				{
+					log_debug("Found mount points: %s\n", *mount_points);
 					volume->mount_point = xstrdup(*mount_points);
+				}
+				else
+				{
+					log_debug("No mount points found (mount_points is %s)\n", mount_points ? "empty" : "NULL");
 				}
 
 				break;


### PR DESCRIPTION
Potential fix for [https://github.com/mcdope/pam_usb/security/code-scanning/231](https://github.com/mcdope/pam_usb/security/code-scanning/231)

The null pointer check for `mount_points` should be performed before dereferencing `*mount_points` in the logging statement. That is, we should only attempt to log `*mount_points` if `mount_points` is not NULL. The best approach is to move the `log_debug("Found mount points: %s\n", *mount_points);` statement into the `if` block that checks for `mount_points` and `*mount_points`. If logging the case when `mount_points` is null is also desired, an explicit log statement can be added for that case to aid debugging, but the key functional fix is to guard the dereference.

The fix involves:
- Moving or copying the `log_debug("Found mount points: %s\n", *mount_points);` statement to after a check for `mount_points != NULL` and `*mount_points != NULL`.
- Optionally, log an alternative message when `mount_points` is NULL or does not point to a string.

This change is localized to lines 129–134 of `src/volume.c`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
