### PR TITLE
Fix memory safety issues across C source modules

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -169,7 +169,7 @@ int pusb_conf_parse(
 	char device_xpath[sizeof(CONF_USER_XPATH) + CONF_USER_MAXLEN + sizeof("device")];
 
 	log_debug("Parsing settings...\n", user, service);
-	if (strnlen(user, sizeof(user)) > CONF_USER_MAXLEN)
+	if (strlen(user) > CONF_USER_MAXLEN)
 	{
 		log_error("Username \"%s\" is too long (max: %d).\n", user, CONF_USER_MAXLEN);
 		return 0;
@@ -193,7 +193,8 @@ int pusb_conf_parse(
 		doc,
 		device_xpath,
 		device_list,
-		sizeof(opts->device.name)
+		sizeof(opts->device.name),
+		10
 	);
 	if (!retval)
 	{

--- a/src/local.c
+++ b/src/local.c
@@ -93,10 +93,11 @@ char *pusb_get_tty_from_display_server(const char *display)
 		if (dent_proc->d_type == DT_DIR && atoi(dent_proc->d_name) != 0 && strcmp(dent_proc->d_name, ".") != 0 && strcmp(dent_proc->d_name, "..") != 0)
 		{
 			memset(cmdline_path, 0, 32);
-			sprintf(cmdline_path, "/proc/%s/cmdline", dent_proc->d_name);
+			snprintf(cmdline_path, 32, "/proc/%s/cmdline", dent_proc->d_name);
 
 			memset(cmdline, 0, 4096);
 			int cmdline_file = open(cmdline_path, O_RDONLY | O_CLOEXEC);
+			if (cmdline_file < 0) continue;
 			int bytes_read = read(cmdline_file, cmdline, 4096);
 			close(cmdline_file);
 			for (int i = 0 ; i < bytes_read; i++) 
@@ -112,7 +113,7 @@ char *pusb_get_tty_from_display_server(const char *display)
 				|| strstr(cmdline, "gdm-wayland-session") != NULL) //@todo: find & add other wayland hosts
 			{
 				memset(fd_path, 0, 32);
-				sprintf(fd_path, "/proc/%s/fd", dent_proc->d_name);
+				snprintf(fd_path, 32, "/proc/%s/fd", dent_proc->d_name);
 
 				DIR *d_fd = opendir(fd_path);
 				if (d_fd == NULL) {
@@ -136,9 +137,11 @@ char *pusb_get_tty_from_display_server(const char *display)
 						memset(link_path, 0, 32);
 						memset(fd_target, 0, 32);
 
-						sprintf(link_path, "/proc/%s/fd/%s", dent_proc->d_name, dent_fd->d_name);
-						if (readlink(link_path, fd_target, 32) != -1)
+						snprintf(link_path, 32, "/proc/%s/fd/%s", dent_proc->d_name, dent_fd->d_name);
+						ssize_t rlen = readlink(link_path, fd_target, 31);
+						if (rlen != -1)
 						{
+							fd_target[rlen] = '\0';
 							if (strstr(fd_target, "/dev/tty") != NULL)
 							{
 								closedir(d_fd);
@@ -176,8 +179,8 @@ char *pusb_get_tty_by_xorg_display(const char *display, const char *user)
 	setutxent();
 	while ((utent = getutxent())) 
 	{
-		if (strncmp(utent->ut_host, display, strnlen(display, sizeof(display))) == 0
-			&& strncmp(utent->ut_user, user, strnlen(user, sizeof(user))) == 0
+		if (strncmp(utent->ut_host, display, strlen(display)) == 0
+			&& strncmp(utent->ut_user, user, strlen(user)) == 0
 			&& (
 				strncmp(utent->ut_line, "tty", sizeof(utent->ut_line)) == 0
 				|| strncmp(utent->ut_line, "console", sizeof(utent->ut_line)) == 0
@@ -186,7 +189,7 @@ char *pusb_get_tty_by_xorg_display(const char *display, const char *user)
 		)
 		{
 			endutxent();
-			return utent->ut_line;
+			return xstrdup(utent->ut_line);
 		}
 	}
 
@@ -200,26 +203,26 @@ char *pusb_get_tty_by_loginctl()
 	char buf[BUFSIZ];
 	FILE *fp;
 
-	if ((fp = popen(loginctl_cmd, "r")) == NULL) 
+	if ((fp = popen(loginctl_cmd, "r")) == NULL)
 	{
 		log_debug("		Opening pipe for 'loginctl' failed, this is quite a wtf...\n");
-		return (0);
+		return NULL;
 	}
 
 	char *tty = NULL;
-	if (fgets(buf, BUFSIZ, fp) != NULL) 
+	if (fgets(buf, BUFSIZ, fp) != NULL)
 	{
 		tty = strtok(buf, "\n");
 		log_debug("		Got tty: %s\n", tty);
 
-		if (pclose(fp)) 
+		if (pclose(fp))
 		{
 			log_debug("		Closing pipe for 'loginctl' failed, this is quite a wtf...\n");
 		}
 
-		return tty;
-	} 
-	else 
+		return tty ? xstrdup(tty) : NULL;
+	}
+	else
 	{
 		log_debug("		'loginctl' returned nothing.\n");
 		if (pclose(fp))
@@ -227,7 +230,7 @@ char *pusb_get_tty_by_loginctl()
 		    log_debug("		Closing pipe for 'loginctl' failed, this is quite a wtf...\n");
 		}
 
-		return (0);
+		return NULL;
 	}
 }
 
@@ -315,7 +318,7 @@ int pusb_local_login(t_pusb_options *opts, const char *user, const char *service
 	}
 
 	const char *session_tty;
-	char *display = getenv("DISPLAY");
+	const char *display_env = getenv("DISPLAY");
 
 	if (local_request == 0 && strstr(name, "tmux") != NULL && tmux_pid != 0) 
 	{
@@ -326,41 +329,44 @@ int pusb_local_login(t_pusb_options *opts, const char *user, const char *service
 		}
 
 		char *tmux_client_tty = pusb_tmux_get_client_tty(tmux_pid);
-		if (tmux_client_tty != NULL && tmux_client_tty != 0) 
+		if (tmux_client_tty != NULL)
 		{
 			local_request = pusb_is_tty_local(tmux_client_tty);
-		} 
-		else if (tmux_client_tty == 0) 
+			xfree(tmux_client_tty);
+		}
+		else
 		{
 			return 0;
 		}
 	}
 
-	if (local_request == 0 && display != NULL) 
+	if (local_request == 0 && display_env != NULL)
 	{
+		char display[256];
+		snprintf(display, sizeof(display), "%s", display_env);
 		log_debug("	Using DISPLAY %s for utmp search\n", display);
 
-		if (strstr(display, ".0") != NULL) 
+		if (strstr(display, ".0") != NULL)
 		{
 			// DISPLAY contains not only display but also default screen, truncate screen part in this case
 			log_debug("	DISPLAY contains screen, truncating...\n");
 			memset(display + strlen(display) - 2, 0, 2);
 		}
 
-		local_request = pusb_is_tty_local((char *) display);
+		local_request = pusb_is_tty_local(display);
 
-		char *xorg_tty = (char *)xmalloc(32);
 		if (local_request == 0)
 		{
 			log_debug("	Trying to get tty from display server\n");
-			xorg_tty = pusb_get_tty_from_display_server(display);
+			char *display_server_tty = pusb_get_tty_from_display_server(display);
 
-			if (xorg_tty != NULL)
+			if (display_server_tty != NULL)
 			{
-				log_debug("	Retrying with tty %s, obtained from display server, for utmp search\n", xorg_tty);
-				local_request = pusb_is_tty_local(xorg_tty);
-			} 
-			else 
+				log_debug("	Retrying with tty %s, obtained from display server, for utmp search\n", display_server_tty);
+				local_request = pusb_is_tty_local(display_server_tty);
+				xfree(display_server_tty);
+			}
+			else
 			{
 				log_debug("		Failed, no result while trying to get TTY from display server\n");
 			}
@@ -368,18 +374,20 @@ int pusb_local_login(t_pusb_options *opts, const char *user, const char *service
 			if (local_request == 0)
 			{
 				log_debug("	Trying to get tty by DISPLAY\n");
-				xorg_tty = pusb_get_tty_by_xorg_display(display, user);
+				char *xorg_tty = pusb_get_tty_by_xorg_display(display, user);
 
 				if (xorg_tty != NULL)
 				{
 					log_debug("	Retrying with tty %s, obtained by DISPLAY, for utmp search\n", xorg_tty);
 					local_request = pusb_is_tty_local(xorg_tty);
-				} else {
+					xfree(xorg_tty);
+				}
+				else
+				{
 					log_debug("		Failed, no result while searching utmp for display %s owned by user %s\n", display, user);
 				}
 			}
 		}
-		xfree(xorg_tty);
 	}
 
 	if (local_request == 0) 
@@ -408,19 +416,17 @@ int pusb_local_login(t_pusb_options *opts, const char *user, const char *service
 			{
 				log_debug("	Trying to get tty by loginctl\n");
 
-				char *loginctl_tty = (char *)xmalloc(32);
-				loginctl_tty = pusb_get_tty_by_loginctl();
-				if (loginctl_tty != 0)
+				char *loginctl_tty = pusb_get_tty_by_loginctl();
+				if (loginctl_tty != NULL)
 				{
 					log_debug("	Retrying with tty %s, obtained by loginctl, for utmp search\n", loginctl_tty);
 					local_request = pusb_is_tty_local(loginctl_tty);
+					xfree(loginctl_tty);
 				}
 				else
 				{
-					log_debug("		Failed, could not obtain tty from loginctl - see line before this for reason.\n", loginctl_tty);
+					log_debug("		Failed, could not obtain tty from loginctl - see line before this for reason.\n");
 				}
-
-				xfree(loginctl_tty);
 			}
 		}
 	}

--- a/src/pad.c
+++ b/src/pad.c
@@ -251,7 +251,7 @@ static int pusb_pad_update(
 		log_debug("/dev/random seeding failed...\n");
 		seed = getpid() * time(NULL); /* low-entropy fallback */
 	}
-	if (devrandom > 0)
+	if (devrandom >= 0)
 	{
 		close(devrandom);
 	}
@@ -280,6 +280,7 @@ void generateRandom(char* output, int sizeBytes)
 	if((fd = open("/dev/random", O_RDONLY)) == -1)
 	{
 		log_error("impossible to read randomness source\n");
+		return;
 	}
 
 	bytes_read = read(fd, output, sizeBytes);

--- a/src/process.c
+++ b/src/process.c
@@ -40,7 +40,7 @@
 void pusb_get_process_name(const pid_t pid, char *name, size_t name_len)
 {
 	char procfile[BUFSIZ];
-	sprintf(procfile, "/proc/%d/cmdline", pid);
+	snprintf(procfile, sizeof(procfile), "/proc/%d/cmdline", pid);
 	FILE* f = fopen(procfile, "r");
 	if (f)
 	{
@@ -60,7 +60,7 @@ void pusb_get_process_name(const pid_t pid, char *name, size_t name_len)
 void pusb_get_process_parent_id(const pid_t pid, pid_t *ppid)
 {
 	char buffer[BUFSIZ];
-	sprintf(buffer, "/proc/%d/stat", pid);
+	snprintf(buffer, sizeof(buffer), "/proc/%d/stat", pid);
 	FILE* fp = fopen(buffer, "r");
 	if (fp)
 	{
@@ -71,7 +71,8 @@ void pusb_get_process_parent_id(const pid_t pid, pid_t *ppid)
 			strtok(NULL, " "); // (2) comm  %s
 			strtok(NULL, " "); // (3) state  %c
 			char *s_ppid = strtok(NULL, " "); // (4) ppid  %d
-			*ppid = atoi(s_ppid);
+			if (s_ppid != NULL)
+				*ppid = atoi(s_ppid);
 		}
 		fclose(fp);
 	}
@@ -95,7 +96,7 @@ char *pusb_get_process_envvar(pid_t pid, char *var)
 	char buffer[BUFSIZ];
 	char *output = NULL;
 
-	sprintf(buffer, "/proc/%d/environ", pid);
+	snprintf(buffer, sizeof(buffer), "/proc/%d/environ", pid);
 	FILE* fp = fopen(buffer, "r");
 	if (fp)
 	{

--- a/src/tmux.c
+++ b/src/tmux.c
@@ -38,14 +38,20 @@ char *pusb_tmux_get_client_tty(pid_t env_pid)
     }
 
     char *tmux_client_id = strrchr(tmux_details, ',');
+    if (tmux_client_id == NULL)
+    {
+        log_debug("		Malformed TMUX env var (no comma), cannot get client id\n");
+        return NULL;
+    }
     tmux_client_id++; // ... to strip leading comma
     log_debug("		Got tmux_client_id: %s\n", tmux_client_id);
 
     char *tmux_socket_path = strtok(tmux_details, ",");
     log_debug("		Got tmux_socket_path: %s\n", tmux_socket_path);
 
-    char get_tmux_session_details_cmd[128];
-    sprintf(get_tmux_session_details_cmd, "LC_ALL=C; tmux -S \"%s\" list-clients -t \"\\$%s\"", tmux_socket_path, tmux_client_id);
+    size_t get_tmux_session_details_cmd_len = strlen(tmux_socket_path) + strlen(tmux_client_id) + 64;
+    char *get_tmux_session_details_cmd = xmalloc(get_tmux_session_details_cmd_len);
+    snprintf(get_tmux_session_details_cmd, get_tmux_session_details_cmd_len, "LC_ALL=C; tmux -S \"%s\" list-clients -t \"\\$%s\"", tmux_socket_path, tmux_client_id);
     log_debug("		Built get_tmux_session_details_cmd: %s\n", get_tmux_session_details_cmd);
 
     char buf[BUFSIZ];
@@ -53,13 +59,21 @@ char *pusb_tmux_get_client_tty(pid_t env_pid)
     if ((fp = popen(get_tmux_session_details_cmd, "r")) == NULL)
     {
         log_error("tmux detected, but couldn't get session details. Denying since remote check impossible without it!\n");
-        return (0);
+        xfree(get_tmux_session_details_cmd);
+        return NULL;
     }
+    xfree(get_tmux_session_details_cmd);
 
     char *tmux_client_tty = NULL;
     if (fgets(buf, BUFSIZ, fp) != NULL)
     {
         tmux_client_tty = strtok(buf, ":");
+        if (tmux_client_tty == NULL)
+        {
+            log_error("tmux detected, but couldn't parse client tty. Denying.\n");
+            pclose(fp);
+            return NULL;
+        }
         tmux_client_tty += 5; // cut "/dev/"
         log_debug("		Got tmux_client_tty: %s\n", tmux_client_tty);
 
@@ -69,10 +83,6 @@ char *pusb_tmux_get_client_tty(pid_t env_pid)
         }
 
         char *result = xmalloc(strlen(tmux_client_tty) + 1);
-        if (result == NULL) {
-            log_error("Memory allocation failed\n");
-            return 0;
-        }
         strcpy(result, tmux_client_tty);
         return result;
     }
@@ -80,7 +90,7 @@ char *pusb_tmux_get_client_tty(pid_t env_pid)
     {
         log_error("tmux detected, but couldn't get client details. Denying since remote check impossible without it!\n");
         pclose(fp);
-        return (0);
+        return NULL;
     }
 }
 

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -132,7 +132,8 @@ int pusb_xpath_get_string_list(
 	xmlDocPtr doc,
 	const char *path,
 	char *values[],
-	size_t size
+	size_t size,
+	int max_count
 )
 {
 	xmlXPathObject *result = NULL;
@@ -144,7 +145,7 @@ int pusb_xpath_get_string_list(
 		return 0;
 	}
 
-	for (int currentResult = 0; currentResult < result->nodesetval->nodeNr; currentResult++)
+	for (int currentResult = 0; currentResult < result->nodesetval->nodeNr && currentResult < max_count; currentResult++)
 	{
 		node = result->nodesetval->nodeTab[currentResult]->xmlChildrenNode;
 		result_string = xmlNodeListGetString(doc, node, 1);

--- a/src/xpath.h
+++ b/src/xpath.h
@@ -20,7 +20,7 @@
 # include <libxml/parser.h>
 
 int pusb_xpath_get_string(xmlDocPtr doc, const char *path, char *value, size_t size);
-int pusb_xpath_get_string_list(xmlDocPtr doc, const char *path, char *value[], size_t size);
+int pusb_xpath_get_string_list(xmlDocPtr doc, const char *path, char *value[], size_t size, int max_count);
 int pusb_xpath_get_string_from(xmlDocPtr doc, const char *base, const char *path, char *value, size_t size);
 int pusb_xpath_get_bool(xmlDocPtr doc, const char *path, int *value);
 int pusb_xpath_get_bool_from(xmlDocPtr doc, const char *base, const char *path, int *value);


### PR DESCRIPTION
  Addresses 18 distinct issues found during a two-pass audit:

  local.c:
  - Replace sprintf with snprintf in pusb_get_tty_from_display_server
  - Guard open() result before read/close (cmdline_file < 0)
  - Null-terminate readlink output (fd_target[rlen] = '\0')
  - Fix strnlen(ptr, sizeof(ptr)) using pointer size instead of strlen
  - Return xstrdup of static utmpx buffer in pusb_get_tty_by_xorg_display to avoid returning pointer into static storage
  - Fix dangling stack pointer in pusb_get_tty_by_loginctl (xstrdup + NULL)
  - Copy getenv("DISPLAY") result before mutation to avoid UB on env string
  - Remove leaked xmalloc(32) stubs; free display_server_tty and xorg_tty immediately after use; free tmux_client_tty and loginctl_tty after use
  - Remove misleading pointer-vs-zero comparison (tmux_client_tty == 0)

  pad.c:
  - generateRandom: return early on open() failure instead of calling read(-1, ...) and close(-1)
  - Fix off-by-one in fd close guard: devrandom > 0 -> devrandom >= 0

  process.c:
  - Replace 3x sprintf with snprintf
  - Guard strtok result before atoi in pusb_get_process_parent_id

  tmux.c:
  - Check strrchr return for NULL before pointer increment
  - Replace fixed 128-byte stack buffer + sprintf for tmux command with dynamic xmalloc + snprintf (buffer was too small for long socket paths)
  - Check strtok return for NULL before += 5 (cut "/dev/")
  - Free get_tmux_session_details_cmd on all exit paths
  - Remove redundant post-xmalloc NULL check (xmalloc aborts on OOM)
  - Replace return (0) with return NULL throughout

  conf.c:
  - Fix strnlen(user, sizeof(user)) using pointer size (8) instead of string length; replace with strlen(user)

  xpath.c / xpath.h:
  - Add max_count parameter to pusb_xpath_get_string_list; cap loop at it to prevent OOB write when XML contains more than 10 device entries