### PR TITLE
Re-introduce the systemd override for the polkit agent, remove succeed_if. Requires socket mode of the agent to be disabled though

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,10 @@ MANS_DEST := $(DESTDIR)$(PREFIX)/share/man/man1
 PAM_CONF := debian/pam-auth-update/usb
 PAM_CONF_DEST := $(DESTDIR)$(PREFIX)/share/pam-configs
 
+# polkit config
+POLKIT_CONF := doc/systemd-polkit-agent-helper-pamusb.conf
+POLKIT_CONF_DEST := $(DESTDIR)$(PREFIX)/lib/systemd/system/polkit-agent-helper@.service.d/
+
 # Binaries
 RM  := rm
 INSTALL	:= install
@@ -154,6 +158,9 @@ install: all
 	if test -f $(CONFS_DEST)/pam_usb.conf; then $(INSTALL) -b -m644 $(CONFS) $(CONFS_DEST)/pam_usb.conf.dist; fi
 	if test ! -f $(CONFS_DEST)/pam_usb.conf; then $(INSTALL) -b -m644 $(CONFS) $(CONFS_DEST); fi
 
+	install -d -m 0755 $(POLKIT_CONF_DEST)
+	$(INSTALL) -m644 $(POLKIT_CONF) $(POLKIT_CONF_DEST)/systemd-polkit-agent-helper-pamusb.conf
+
 # force pam-auth-update config install if building a deb
 	if test $(DEB_TARGET_ARCH) != "" > /dev/null 2>&1; then mkdir -p $(PAM_CONF_DEST) && $(INSTALL) -m644 $(PAM_CONF) $(PAM_CONF_DEST)/libpam-usb; fi
 
@@ -167,7 +174,8 @@ deinstall:
 		$(TOOLS_DEST)/$(PAMUSB_AGENT) \
 		$(TOOLS_DEST)/$(PAMUSB_KEYRING_GNOME) \
 		$(TOOLS_DEST)/$(PAMUSB_PINENTRY) \
-		$(PAM_CONF_DEST)/$(PAM_CONF)
+		$(PAM_CONF_DEST)/$(PAM_CONF) \
+		$(POLKIT_CONF_DEST)/systemd-polkit-agent-helper-pamusb.conf
 
 	$(RM) -rf $(DOCS_DEST)
 	$(RM) -f $(MANS_DEST)/pamusb-*\.1\.gz

--- a/debian/pam-auth-update/usb
+++ b/debian/pam-auth-update/usb
@@ -4,8 +4,6 @@ Priority: 1000
 
 Auth-Type: Primary
 Auth:
-    [success=1 default=ignore]	pam_succeed_if.so service = polkit-1 quiet
 	sufficient	pam_usb.so
 Auth-Initial:
-    [success=1 default=ignore]	pam_succeed_if.so service = polkit-1 quiet
 	sufficient	pam_usb.so

--- a/doc/QUICKSTART
+++ b/doc/QUICKSTART
@@ -77,7 +77,6 @@ This is a current standard which uses passwords to authenticate a user.
 
 Alter your `/etc/pam.d/common-auth` configuration to:
 
-    [success=1 default=ignore]	pam_succeed_if.so service = polkit-1 quiet
     auth    sufficient      pam_usb.so
     auth    required        pam_unix.so nullok_secure
 
@@ -124,9 +123,9 @@ You should think twice if you want to enable this feature. To use it you need to
 The tool will only work if that file has permissions only for the owner, however - anyone with root/sudo access will still be able to read it. Keep that in mind before using this feature. Even worse: if you have samba user shares enabled you would share your password via SMB shares - to whoever can access that share. To be clear: this is a comfort feature and is insecure by design. 
 
 If you still want to use it, you will have to do four things:
-* create `.keyring_unlock_password` in `~/`
+* create `.keyring_unlock_password` in `~/.pamusb/`
 * in that file you put `UNLOCK_PASSWORD="your_password"` (including the quotes)
-* set permissions so only yourself (and root) can read the file by running `chmod 0600 ~/.keyring_unlock_password`
+* set permissions so only yourself (and root) can read the file by running `chmod 0600 ~/.pamusb/.keyring_unlock_password`
 * create an autostart entry in GNOME for `/usr/bin/pamusb-keyring-unlock-gnome`
 
 Auto-unlock your GPG keys

--- a/doc/TROUBLESHOOTING
+++ b/doc/TROUBLESHOOTING
@@ -114,15 +114,35 @@ There is now a profile available for Fedora 40 that you can install to allow pam
 
 In case it doesn't work for you, see the discussion at https://github.com/mcdope/pam_usb/discussions/241 to find out how to create your own profile.
 
-PolicyKit and pam_usb
+PolicyKit 127 and pam_usb
 --------------
 
-PolicyKit and pam_usb are incompatible by design, since polkit isn't made for conversation less authentication flow. Modules like fingerprint have special dbus integrations in polkit allowing them to work, which is not an option for us. For more details see https://github.com/mcdope/pam_usb/issues/278#issuecomment-4365862274 and the comments below.
+PolicyKit starting from 127 and pam_usb are incompatible in the default configuration. This is caused by the [introduction of a socket based polkit-agent-helper](https://github.com/polkit-org/polkit/commit/c007940054392b67b84b6044dda8a215040d8eb5). You will have to a) disable the socket service b) re-enable suid and c) redo that on every polkit upgrade until they fix their agent (not only pam_usb is influenced by this). 
 
-You need to actively exclude pam_usb from polkit-1 authentication requests. This can be done by putting the following line BEFORE your pam_usb line in your pam config:
+Details:
 
+#### 1. Disable the Systemd Socket
+Stop and disable the socket so systemd stops intercepting the authentication requests. Open your terminal and run:
+```bash
+sudo systemctl disable --now polkit-agent-helper.socket
 ```
-[success=1 default=ignore]	pam_succeed_if.so service = polkit-1 quiet
-```
 
-On Debian based distributions this is done automatically when installed from package.
+#### 2. Restore the SUID Bit on the Helper Binary
+Because you disabled the socket, polkit will fall back to executing the agent helper directly. For this to work, the binary **must** have the SUID (Set Owner User ID) bit set. Since your distribution's package manager likely stripped this bit in the v127 update, you will need to restore it manually.
+
+First, locate your `polkit-agent-helper-1` binary. It is typically found at one of these two paths, depending on your distribution:
+* `/usr/lib/polkit-1/polkit-agent-helper-1` (Debian, Ubuntu, Fedora, openSUSE)
+* `/usr/libexec/polkit-1/polkit-agent-helper-1` (Arch Linux)
+
+Once you confirm the path, restore the SUID bit and set root ownership:
+```bash
+sudo chown root:root /usr/lib/polkit-1/polkit-agent-helper-1
+sudo chmod u+s /usr/lib/polkit-1/polkit-agent-helper-1
+```
+*(Remember to replace the path if your system uses the `/usr/libexec/` directory).*
+
+#### A Quick Warning on Package Updates
+Because you are modifying the permissions of a package-managed file manually, a future update to the `polkit` package might overwrite your changes and strip the SUID bit again. Many distributions are currently working on patches or have temporarily downgraded polkit to `126` in their repositories, so keeping your system up-to-date should eventually resolve the underlying bug natively.
+
+#### Alternative way, without messing with polkit
+Create a copy of your common-auth pam config (or whatever file it is on your distribution) and name it polkit-1. Remove pam_usb from it. 

--- a/doc/systemd-polkit-agent-helper-pamusb.conf
+++ b/doc/systemd-polkit-agent-helper-pamusb.conf
@@ -1,0 +1,3 @@
+[Service]
+
+ProtectHome=no

--- a/fedora/SPECS/pam_usb.spec
+++ b/fedora/SPECS/pam_usb.spec
@@ -48,6 +48,7 @@ rm -rf %{buildroot}/usr/share/pam-configs
 %attr(0755,root,root) /usr/bin/pamusb-pinentry
 
 %config(noreplace) %attr(0644,root,root) /etc/security/pam_usb.conf
+%config(noreplace) %attr(0644,root,root) /usr/lib/systemd/system/polkit-agent-helper@.service.d/systemd-polkit-agent-helper-pamusb.conf
 
 %doc %attr(0644,root,root) /usr/share/man/man1/pamusb-agent.1.gz
 %doc %attr(0644,root,root) /usr/share/man/man1/pamusb-check.1.gz


### PR DESCRIPTION
This reverts commit 65dfaaf79e59468b22366a17b8582c7e55dc151e.

Requires socket mode to be disabled!!!

"socket-mode" was introduced in PolicyKit (polkit) version 127. It uses a systemd socket-activated service (`polkit-agent-helper.socket`) in an effort to transition away from using SUID root binaries, which are considered a security risk. 

However, this transition has temporarily broken several authentication methods (like SSH keyfile auth, YubiKey/pam_u2f, and certain graphical prompts) across various Linux distributions.

To disable the socket-mode and revert to the legacy behavior, you need to disable the systemd socket and manually restore the SUID bit on the helper binary. Here is how you do it:

### 1. Disable the Systemd Socket
Stop and disable the socket so systemd stops intercepting the authentication requests. Open your terminal and run:
```bash
sudo systemctl disable --now polkit-agent-helper.socket
```

### 2. Restore the SUID Bit on the Helper Binary
Because you disabled the socket, polkit will fall back to executing the agent helper directly. For this to work, the binary **must** have the SUID (Set Owner User ID) bit set. Since your distribution's package manager likely stripped this bit in the v127 update, you will need to restore it manually.

First, locate your `polkit-agent-helper-1` binary. It is typically found at one of these two paths, depending on your distribution:
* `/usr/lib/polkit-1/polkit-agent-helper-1` (Debian, Ubuntu, Fedora, openSUSE)
* `/usr/libexec/polkit-1/polkit-agent-helper-1` (Arch Linux)

Once you confirm the path, restore the SUID bit and set root ownership:
```bash
sudo chown root:root /usr/lib/polkit-1/polkit-agent-helper-1
sudo chmod u+s /usr/lib/polkit-1/polkit-agent-helper-1
```
*(Remember to replace the path if your system uses the `/usr/libexec/` directory).*

### A Quick Warning on Package Updates
Because you are modifying the permissions of a package-managed file manually, a future update to the `polkit` package might overwrite your changes and strip the SUID bit again. Many distributions are currently working on patches or have temporarily downgraded polkit to `126` in their repositories, so keeping your system up-to-date should eventually resolve the underlying bug natively.

See #278 and #281 