### PR TITLE
add pinentry deps to the debian package (#280)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,6 @@ Package: libpam-usb
 Architecture: any
 # Multi-Arch: same
 Pre-Depends: libpam-runtime (>= 1.0.1-6~), ${misc:Pre-Depends}
-Depends: ${shlibs:Depends}, ${misc:Depends}, python3, python3-gi, udisks2, gir1.2-udisks-2.0, libpam0g, libxml2, libglib2.0-0, gawk
+Depends: ${shlibs:Depends}, ${misc:Depends}, python3, python3-gi, python3-dotenv, udisks2, gir1.2-udisks-2.0, libpam0g, libxml2, libglib2.0-0, gawk
 Description: Adds auth over usb-stick to pam
  Provides a new pam module, pam_usb.so, that can be used in pam.d/common-auth


### PR DESCRIPTION
This adds the pamusb pinentry dependency.

At least on Debian, when installing the package, the system’s default pinentry is updated to pamusb_pinentry, but it fails as mentioned in issue #280 because the python3-dotenv dependency is missing.