### PR TITLE
Prepare v0.8.7

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+* 0.8.7
+  [Enhancement] Specify a dedicated device for superuser services
+  [Enhancement] Restore PolicyKit support (also for 127)
+  [Enhancement] Remove default installation of pamusb-pinentry
+  [Security] Fixed GHSA-822m-whrh-vrj8
+  [Security] Fixed GHSA-jgv5-w6rm-7wxg
+  [Security] Fixed GHSA-fjpm-p9pj-mp34
+  [Security] Fixed GHSA-j8cq-2gv6-gfwf
+  [Security] Fixed GHSA-jxrj-q67x-wr4c
+
 * 0.8.6
   [Enhancement] Documentation updates
   [Enhancement] Remote VSCode tunnels are now detected in deny_remote check (thx @jaoppb)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,10 +5,16 @@
 At every point in time only the most recent release is supported.
 
 | Version | Supported          |
-| ------- | ------------------ |
-| 0.8.6   | :white_check_mark: |
-| < 0.8.6 | :x:                |
+|---------| ------------------ |
+| 0.8.7   | :white_check_mark: |
+| < 0.8.7 | :x:                |
 
 ## Reporting a Vulnerability
 
 Please email me at tobiasbaeumer@gmail.com, since Github issues are public.
+
+## Note on versions <= 0.8.6
+
+There are multiple not yet published security advisories for these versions. Details will follow.
+
+But if you're running anything except 0.8.7 please update immediately!

--- a/arch_linux/PKGBUILD_git
+++ b/arch_linux/PKGBUILD_git
@@ -2,7 +2,7 @@
 # Contributor: Pekka Helenius <fincer89 [at] hotmail [dot] com>
 
 pkgname=pam_usb-git
-pkgver=0.8.6_r589.g370655a
+pkgver=0.8.7_r596.g9bce707
 pkgrel=1
 pkgdesc='Hardware authentication for Linux using ordinary flash media (USB & Card based).'
 arch=($CARCH)

--- a/arch_linux/PKGBUILD_stable
+++ b/arch_linux/PKGBUILD_stable
@@ -2,7 +2,7 @@
 # Contributor: Pekka Helenius <fincer89 [at] hotmail [dot] com>
 
 pkgname=pam_usb
-pkgver=0.8.6
+pkgver=0.8.7
 pkgrel=1
 pkgdesc='Hardware authentication for Linux using ordinary flash media (USB & Card based).'
 arch=($CARCH)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+libpam-usb (0.8.7) unstable; urgency=critical
+  * [Enhancement] Specify a dedicated device for superuser services
+  * [Enhancement] Restore PolicyKit support (also for 127)
+  * [Enhancement] Remove default installation of pamusb-pinentry
+  * [Security] Fixed GHSA-822m-whrh-vrj8
+  * [Security] Fixed GHSA-jgv5-w6rm-7wxg
+  * [Security] Fixed GHSA-fjpm-p9pj-mp34
+  * [Security] Fixed GHSA-j8cq-2gv6-gfwf
+  * [Security] Fixed GHSA-jxrj-q67x-wr4c
+
+ -- Tobias Bäumer <tobiasbaeumer@gmail.com>  Tue, 05 May 2026 21:00:00 +0200
+
 libpam-usb (0.8.6) unstable; urgency=medium
   * [Enhancement] Documentation updates
   * [Enhancement] Remote VSCode tunnels are now detected in deny_remote check (thx @jaoppb)

--- a/fedora/SPECS/pam_usb.spec
+++ b/fedora/SPECS/pam_usb.spec
@@ -1,7 +1,7 @@
 %define _topdir         /usr/local/src/pam_usb/fedora
 %define name            pam_usb 
 %define release         1
-%define version         0.8.6
+%define version         0.8.7
 %define buildroot       %{_topdir}/%{name}‑%{version}‑root
 
 BuildRoot: %{buildroot}
@@ -61,6 +61,17 @@ rm -rf %{buildroot}/usr/share/pam-configs
 %doc %attr(0644,root,root) /usr/share/doc/pam_usb/TROUBLESHOOTING
 
 %changelog
+
+* Tue May 05 2026 Tobias Bäumer <tobiasbaeumer@gmail.com> - 0.8.7
+- [Enhancement] Specify a dedicated device for superuser services
+- [Enhancement] Restore PolicyKit support (also for 127)
+- [Enhancement] Remove default installation of pamusb-pinentry
+- [Security] Fixed GHSA-822m-whrh-vrj8
+- [Security] Fixed GHSA-jgv5-w6rm-7wxg
+- [Security] Fixed GHSA-fjpm-p9pj-mp34
+- [Security] Fixed GHSA-j8cq-2gv6-gfwf
+- [Security] Fixed GHSA-jxrj-q67x-wr4c
+
 * Fri May 03 2026 Tobias Bäumer <tobiasbaeumer@gmail.com> - 0.8.6
 - [Enhancement] Documentation updates
 - [Enhancement] Remote VSCode tunnels are now detected in deny_remote check (thx @jaoppb)

--- a/src/version.h
+++ b/src/version.h
@@ -18,6 +18,6 @@
 #ifndef PUSB_VERSION_H_
 # define PUSB_VERSION_H_
 
-# define PUSB_VERSION "0.8.6"
+# define PUSB_VERSION "0.8.7"
 
 #endif /* !PUSB_VERSION_H_ */


### PR DESCRIPTION
* 0.8.7
  [Enhancement] Specify a dedicated device for superuser services
  [Enhancement] Restore PolicyKit support (also for 127)
  [Enhancement] Remove default installation of pamusb-pinentry
  [Security] Fixed GHSA-822m-whrh-vrj8
  [Security] Fixed GHSA-jgv5-w6rm-7wxg
  [Security] Fixed GHSA-fjpm-p9pj-mp34
  [Security] Fixed GHSA-j8cq-2gv6-gfwf
  [Security] Fixed GHSA-jxrj-q67x-wr4c