### PR TITLE
#223: Add integration test for superuser device filtering

### DIFF
--- a/tests/can-actually-be-used/run-tests.sh
+++ b/tests/can-actually-be-used/run-tests.sh
@@ -11,4 +11,5 @@ rm -rf /home/`whoami`/.pamusb
 ./test-conf-adds-user.sh && \
 ./test-conf-doesnt-add-user-twice-but-adds-a-second-device.sh && \
 ./test-check-verify-created-config.sh && \
+./test-check-superuser-filtering.sh && \
 ./test-agent-properly-triggers.sh

--- a/tests/can-actually-be-used/test-check-superuser-filtering.sh
+++ b/tests/can-actually-be-used/test-check-superuser-filtering.sh
@@ -4,7 +4,7 @@ WHOAMI=$(whoami)
 CONF=/etc/security/pam_usb.conf
 TMP_SU=/tmp/pam_usb_test_su_enabled.conf
 TMP_NO_SU=/tmp/pam_usb_test_su_disabled.conf
-SERVICE_ENTRY='<service id="test-sudo"><option name="superuser">true</option></service>'
+SERVICE_ENTRY='<services><service id="test-sudo"><option name="superuser">true</option></service></services>'
 
 # variant-A: test2 marked superuser + service requires superuser
 sed 's|<device>test2</device>|<device superuser="true">test2</device>|' "$CONF" | \

--- a/tests/can-actually-be-used/test-check-superuser-filtering.sh
+++ b/tests/can-actually-be-used/test-check-superuser-filtering.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/bash
+
+WHOAMI=$(whoami)
+CONF=/etc/security/pam_usb.conf
+TMP_SU=/tmp/pam_usb_test_su_enabled.conf
+TMP_NO_SU=/tmp/pam_usb_test_su_disabled.conf
+SERVICE_ENTRY='<service id="test-sudo"><option name="superuser">true</option></service>'
+
+# variant-A: test2 marked superuser + service requires superuser
+sed 's|<device>test2</device>|<device superuser="true">test2</device>|' "$CONF" | \
+    sed "s|</configuration>|${SERVICE_ENTRY}</configuration>|" > "$TMP_SU"
+
+# variant-B: test2 NOT marked superuser, but service still requires superuser
+sed "s|</configuration>|${SERVICE_ENTRY}</configuration>|" "$CONF" > "$TMP_NO_SU"
+
+echo -e "Test:\t\t\tsuperuser device accepted for superuser-required service"
+pamusb-check --debug --config="$TMP_SU" --service=test-sudo "$WHOAMI" && \
+    echo -e "Result:\t\t\tPASSED!" || \
+    { echo "FAILED: superuser device should be accepted for superuser-required service"; rm -f "$TMP_SU" "$TMP_NO_SU"; exit 1; }
+
+echo -e "Test:\t\t\tnon-superuser device rejected for superuser-required service"
+if pamusb-check --debug --config="$TMP_NO_SU" --service=test-sudo "$WHOAMI"; then
+    echo "FAILED: non-superuser device should be rejected for superuser-required service"
+    rm -f "$TMP_SU" "$TMP_NO_SU"
+    exit 1
+fi
+echo -e "Result:\t\t\tPASSED!"
+
+echo -e "Test:\t\t\tnon-superuser device accepted for non-superuser service (backward compat)"
+pamusb-check --debug --config="$TMP_NO_SU" "$WHOAMI" && \
+    echo -e "Result:\t\t\tPASSED!" || \
+    { echo "FAILED: non-superuser device should work for non-superuser service"; rm -f "$TMP_SU" "$TMP_NO_SU"; exit 1; }
+
+rm -f "$TMP_SU" "$TMP_NO_SU"


### PR DESCRIPTION
Covers all three outcomes of the filtering logic in conf.c:279-293:
- superuser device accepted for a superuser-required service
- non-superuser device rejected for a superuser-required service
- non-superuser device accepted for a non-superuser service (backward compat)

Config variants are built on-the-fly from the live config using sed, so no device swap is needed — all three checks run with the test2 stick already plugged by the preceding test.