### PR TITLE
Chain GitHub workflows sequentially via workflow_run triggers

### DIFF
--- a/.github/workflows/build-and-test-on-own-server.yml
+++ b/.github/workflows/build-and-test-on-own-server.yml
@@ -1,14 +1,22 @@
 name: Build & test
 
 on:
-  pull_request:
-    branches: [ master ]
-  push:
-    branches: [ master ]
+  workflow_run:
+    workflows: ["Packaging (deb, rpm, zst)"]
+    types: [completed]
 
 jobs:
-  DoMagicOnConfiguredCustomRunner:
+  check-prerequisite:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Fail if upstream workflow failed
+        if: ${{ github.event.workflow_run.conclusion != 'success' }}
+        run: |
+          echo "Upstream workflow '${{ github.event.workflow_run.name }}' did not succeed (conclusion: ${{ github.event.workflow_run.conclusion }})"
+          exit 1
 
+  DoMagicOnConfiguredCustomRunner:
+    needs: check-prerequisite
     runs-on: ubuntu-22.04
 
     steps:
@@ -64,7 +72,7 @@ jobs:
         TEST_RUNNER_USER_NEW: ${{ secrets.TEST_RUNNER_USER_NEW }}
         TEST_RUNNER_PASS_NEW: ${{ secrets.TEST_RUNNER_PASS_2025 }}
         TEST_RUNNER_PORT_NEW: ${{ secrets.TEST_RUNNER_PORT_NEW }}
-        REF_TO_CHECKOUT: ${{ github.head_ref }}
+        REF_TO_CHECKOUT: ${{ github.event.workflow_run.head_branch }}
       run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "cd ~/pam_usb_$GITHUB_RUN_ID && git switch -f $REF_TO_CHECKOUT || git switch -f master"
     - name: git pull
       env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,17 +6,28 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [master]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [master]
+  workflow_run:
+    workflows: ["Unit tests"]
+    types: [completed]
   schedule:
     - cron: '0 7 * * 2'
 
 jobs:
+  check-prerequisite:
+    runs-on: ubuntu-22.04
+    if: ${{ github.event_name == 'workflow_run' }}
+    steps:
+      - name: Fail if upstream workflow failed
+        if: ${{ github.event.workflow_run.conclusion != 'success' }}
+        run: |
+          echo "Upstream workflow '${{ github.event.workflow_run.name }}' did not succeed (conclusion: ${{ github.event.workflow_run.conclusion }})"
+          exit 1
+
   analyze:
     name: Analyze
+    needs:
+      - check-prerequisite
+    if: ${{ always() && (needs.check-prerequisite.result == 'success' || github.event_name == 'schedule') }}
     runs-on: ubuntu-22.04
 
     strategy:
@@ -42,13 +53,13 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
+        # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
-      
+
     - name: Install requirements
       run: sudo apt install libudisks2-dev libxml2-dev python-is-python3 libpam0g-dev pkg-config gir1.2-glib-2.0 libglib2.0-dev
     - name: make

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -6,16 +6,28 @@
 name: DevSkim
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  workflow_run:
+    workflows: ["CodeQL"]
+    types: [completed]
   schedule:
     - cron: '31 19 * * 5'
 
 jobs:
+  check-prerequisite:
+    runs-on: ubuntu-22.04
+    if: ${{ github.event_name == 'workflow_run' }}
+    steps:
+      - name: Fail if upstream workflow failed
+        if: ${{ github.event.workflow_run.conclusion != 'success' }}
+        run: |
+          echo "Upstream workflow '${{ github.event.workflow_run.name }}' did not succeed (conclusion: ${{ github.event.workflow_run.conclusion }})"
+          exit 1
+
   lint:
     name: DevSkim
+    needs:
+      - check-prerequisite
+    if: ${{ always() && (needs.check-prerequisite.result == 'success' || github.event_name == 'schedule') }}
     runs-on: ubuntu-22.04
     permissions:
       actions: read
@@ -27,7 +39,7 @@ jobs:
 
       - name: Run DevSkim scanner
         uses: microsoft/DevSkim-Action@v1
-        
+
       - name: Upload DevSkim scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/package-with-docker-on-own-server.yml
+++ b/.github/workflows/package-with-docker-on-own-server.yml
@@ -1,14 +1,22 @@
 name: Packaging (deb, rpm, zst)
 
 on:
-  pull_request:
-    branches: [ master ]
-  push:
-    branches: [ master ]
+  workflow_run:
+    workflows: ["DevSkim"]
+    types: [completed]
 
 jobs:
-  Debian:
+  check-prerequisite:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Fail if upstream workflow failed
+        if: ${{ github.event.workflow_run.conclusion != 'success' }}
+        run: |
+          echo "Upstream workflow '${{ github.event.workflow_run.name }}' did not succeed (conclusion: ${{ github.event.workflow_run.conclusion }})"
+          exit 1
 
+  Debian:
+    needs: check-prerequisite
     runs-on: ubuntu-22.04
 
     steps:
@@ -43,7 +51,7 @@ jobs:
         TEST_RUNNER_USER_NEW: ${{ secrets.TEST_RUNNER_USER_NEW }}
         TEST_RUNNER_PASS_NEW: ${{ secrets.TEST_RUNNER_PASS_2025 }}
         TEST_RUNNER_PORT_NEW: ${{ secrets.TEST_RUNNER_PORT_NEW }}
-        REF_TO_CHECKOUT: ${{ github.head_ref }}
+        REF_TO_CHECKOUT: ${{ github.event.workflow_run.head_branch }}
       run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "cd ~/pam_usb_deb_$GITHUB_RUN_ID && git switch -f $REF_TO_CHECKOUT || git switch -f master"
     - name: git pull
       env:
@@ -77,7 +85,7 @@ jobs:
 
 
   Fedora:
-
+    needs: check-prerequisite
     runs-on: ubuntu-22.04
 
     steps:
@@ -112,7 +120,7 @@ jobs:
         TEST_RUNNER_USER_NEW: ${{ secrets.TEST_RUNNER_USER_NEW }}
         TEST_RUNNER_PASS_NEW: ${{ secrets.TEST_RUNNER_PASS_2025 }}
         TEST_RUNNER_PORT_NEW: ${{ secrets.TEST_RUNNER_PORT_NEW }}
-        REF_TO_CHECKOUT: ${{ github.head_ref }}
+        REF_TO_CHECKOUT: ${{ github.event.workflow_run.head_branch }}
       run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "cd ~/pam_usb_rpm_$GITHUB_RUN_ID && git switch -f $REF_TO_CHECKOUT || git switch -f master"
     - name: git pull
       env:
@@ -145,7 +153,7 @@ jobs:
       run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -tt -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "sudo rm -rf ~/pam_usb_rpm_$GITHUB_RUN_ID"
 
   Arch:
-
+    needs: check-prerequisite
     runs-on: ubuntu-22.04
 
     steps:
@@ -180,7 +188,7 @@ jobs:
         TEST_RUNNER_USER_NEW: ${{ secrets.TEST_RUNNER_USER_NEW }}
         TEST_RUNNER_PASS_NEW: ${{ secrets.TEST_RUNNER_PASS_2025 }}
         TEST_RUNNER_PORT_NEW: ${{ secrets.TEST_RUNNER_PORT_NEW }}
-        REF_TO_CHECKOUT: ${{ github.head_ref }}
+        REF_TO_CHECKOUT: ${{ github.event.workflow_run.head_branch }}
       run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "cd ~/pam_usb_arch_$GITHUB_RUN_ID && git switch -f $REF_TO_CHECKOUT || git switch -f master"
     - name: git pull
       env:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,13 +1,22 @@
 name: Unit tests
 
 on:
-  pull_request:
-    branches: [ master ]
-  push:
-    branches: [ master ]
+  workflow_run:
+    workflows: ["Can be built successfully"]
+    types: [completed]
 
 jobs:
+  check-prerequisite:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Fail if upstream workflow failed
+        if: ${{ github.event.workflow_run.conclusion != 'success' }}
+        run: |
+          echo "Upstream workflow '${{ github.event.workflow_run.name }}' did not succeed (conclusion: ${{ github.event.workflow_run.conclusion }})"
+          exit 1
+
   unit-tests:
+    needs: check-prerequisite
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
## Summary

- Each workflow now triggers only after its predecessor completes successfully via `workflow_run` triggers
- Enforces the order: **build → unit-tests → codeql → devskim → packaging**
- A `check-prerequisite` job at the start of each downstream workflow fails explicitly if the upstream conclusion was not `success`, so the pipeline visibly fails rather than silently skipping

## Test plan

- [ ] Push a change to a branch targeting master and verify workflows fire in order
- [ ] Introduce a deliberate build failure and verify downstream workflows do not run (and show as failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)