### PR TITLE
#121: Add --install/--uninstall to pamusb-keyring-unlock-gnome

### DIFF
--- a/doc/QUICKSTART
+++ b/doc/QUICKSTART
@@ -122,11 +122,14 @@ You should think twice if you want to enable this feature. To use it you need to
 
 The tool will only work if that file has permissions only for the owner, however - anyone with root/sudo access will still be able to read it. Keep that in mind before using this feature. Even worse: if you have samba user shares enabled you would share your password via SMB shares - to whoever can access that share. To be clear: this is a comfort feature and is insecure by design. 
 
-If you still want to use it, you will have to do four things:
-* create `.keyring_unlock_password` in `~/.pamusb/`
-* in that file you put `UNLOCK_PASSWORD="your_password"` (including the quotes)
-* set permissions so only yourself (and root) can read the file by running `chmod 0600 ~/.pamusb/.keyring_unlock_password`
-* create an autostart entry in GNOME for `/usr/bin/pamusb-keyring-unlock-gnome`
+If you still want to use it, run:
+
+    pamusb-keyring-unlock-gnome --install
+
+and follow the prompts. This creates the password file with correct permissions and installs
+the GNOME autostart entry. To undo, run:
+
+    pamusb-keyring-unlock-gnome --uninstall
 
 Auto-unlock your GPG keys
 ------------------------------

--- a/doc/pamusb-keyring-unlock-gnome.1
+++ b/doc/pamusb-keyring-unlock-gnome.1
@@ -2,6 +2,19 @@
 
 .SH NAME
 \fBpamusb-keyring-unlock-gnome \fP- pam_usb unlock tool for the gnome-keyring
+.SH SYNOPSIS
+\fBpamusb-keyring-unlock-gnome\fP [\-\-install|\-\-uninstall]
+.SH OPTIONS
+.TP
+\fB\-\-install\fP
+Creates the password file skeleton (\fI~/.pamusb/.keyring_unlock_password\fP, mode 0600),
+installs the GNOME autostart desktop entry, and overrides the default gnome-keyring secrets
+daemon autostart so this script controls when the keyring is unlocked.
+Prompts for the keyring password interactively, or reads it from stdin when stdin is not a
+terminal.
+.TP
+\fB\-\-uninstall\fP
+Removes all files created by \-\-install.
 .SH DESCRIPTION
 \fBpamusb-keyring-unlock-gnome\fP is a tool to unlock your GNOME keyring when used with pam_usb autologin.
 .SH CONFIGURATION

--- a/tests/can-actually-be-used/run-tests.sh
+++ b/tests/can-actually-be-used/run-tests.sh
@@ -6,6 +6,7 @@ set -e
 rm -rf /home/`whoami`/.pamusb
 
 # Run tests
+./test-keyring-unlock-gnome-installer.sh && \
 ./test-conf-detects-device.sh && \
 ./test-conf-adds-device.sh && \
 ./test-conf-adds-user.sh && \

--- a/tests/can-actually-be-used/test-keyring-unlock-gnome-installer.sh
+++ b/tests/can-actually-be-used/test-keyring-unlock-gnome-installer.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/bash
+set -e
+echo -e "Test:\t\t\tpamusb-keyring-unlock-gnome --install / --uninstall"
+
+FAKE_HOME=$(mktemp -d)
+trap "rm -rf $FAKE_HOME" EXIT
+
+TOOL=$(which pamusb-keyring-unlock-gnome)
+
+# --install: pipe password via stdin (non-interactive path, no stty needed)
+printf 'testpassword\n' | HOME=$FAKE_HOME $TOOL --install
+
+# verify password file exists with mode 0600
+[ -f "$FAKE_HOME/.pamusb/.keyring_unlock_password" ]
+PERMS=$(stat -c "%a" "$FAKE_HOME/.pamusb/.keyring_unlock_password")
+[ "$PERMS" = "600" ]
+grep -q 'UNLOCK_PASSWORD="testpassword"' "$FAKE_HOME/.pamusb/.keyring_unlock_password"
+
+# verify autostart desktop file created with autostart enabled
+[ -f "$FAKE_HOME/.config/autostart/pamusb-keyring-unlock-gnome.desktop" ]
+grep -q 'X-GNOME-Autostart-enabled=true' "$FAKE_HOME/.config/autostart/pamusb-keyring-unlock-gnome.desktop"
+
+# verify gnome-keyring-secrets override created to prevent daemon from racing our script
+[ -f "$FAKE_HOME/.config/autostart/gnome-keyring-secrets.desktop" ]
+grep -q 'Hidden=true' "$FAKE_HOME/.config/autostart/gnome-keyring-secrets.desktop"
+
+# --uninstall
+HOME=$FAKE_HOME $TOOL --uninstall
+
+# verify all three files are removed
+[ ! -f "$FAKE_HOME/.pamusb/.keyring_unlock_password" ]
+[ ! -f "$FAKE_HOME/.config/autostart/pamusb-keyring-unlock-gnome.desktop" ]
+[ ! -f "$FAKE_HOME/.config/autostart/gnome-keyring-secrets.desktop" ]
+
+echo -e "Result:\t\t\tPASSED!"

--- a/tools/pamusb-keyring-unlock-gnome
+++ b/tools/pamusb-keyring-unlock-gnome
@@ -15,6 +15,78 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
 # Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+INSTALL=0
+UNINSTALL=0
+
+while [ "$1" != "" ]; do
+    case $1 in
+        --install)   INSTALL=1 ;;
+        --uninstall) UNINSTALL=1 ;;
+        *) printf 'Usage: %s [--install|--uninstall]\n' "${0##*/}" >&2; exit 1 ;;
+    esac
+    shift
+done
+
+do_install() {
+    if [ "$(id -u)" = "0" ]; then
+        printf 'Do not run --install as root; files belong in your user home.\n' >&2
+        exit 1
+    fi
+
+    if [ -t 0 ]; then
+        printf 'Enter your keyring unlock password: '
+        stty -echo
+        read -r UNLOCK_PASSWORD
+        stty echo
+        printf '\n'
+    else
+        read -r UNLOCK_PASSWORD
+    fi
+
+    mkdir -p "$HOME/.pamusb"
+    printf 'UNLOCK_PASSWORD="%s"\n' "$UNLOCK_PASSWORD" > "$HOME/.pamusb/.keyring_unlock_password"
+    chmod 0600 "$HOME/.pamusb/.keyring_unlock_password"
+
+    mkdir -p "$HOME/.config/autostart"
+
+    cat > "$HOME/.config/autostart/pamusb-keyring-unlock-gnome.desktop" <<'EOF'
+[Desktop Entry]
+Type=Application
+Exec=/usr/bin/pamusb-keyring-unlock-gnome
+Hidden=false
+NoDisplay=false
+X-GNOME-Autostart-enabled=true
+Name=pam_usb keyring unlock
+Comment=Unlock GNOME keyring with pam_usb
+EOF
+
+    cat > "$HOME/.config/autostart/gnome-keyring-secrets.desktop" <<'EOF'
+[Desktop Entry]
+Hidden=true
+EOF
+
+    printf '\nInstallation complete.\n'
+    printf 'WARNING: Your keyring password is stored in cleartext at %s/.pamusb/.keyring_unlock_password\n' "$HOME"
+    printf 'Make sure your home directory is encrypted if you rely on this feature for security.\n'
+}
+
+do_uninstall() {
+    rm -f "$HOME/.pamusb/.keyring_unlock_password"
+    rm -f "$HOME/.config/autostart/pamusb-keyring-unlock-gnome.desktop"
+    rm -f "$HOME/.config/autostart/gnome-keyring-secrets.desktop"
+    printf 'Uninstall complete. Removed password file and autostart entries.\n'
+}
+
+if [ "$INSTALL" = "1" ]; then
+    do_install
+    exit 0
+fi
+
+if [ "$UNINSTALL" = "1" ]; then
+    do_uninstall
+    exit 0
+fi
+
 # Check for valid authentication
 pamusb-check `whoami` > /dev/null 2>&1 || (logger -p local0.error -t ${0##*/}[$$] pamusb-check failed. && exit 1)
 


### PR DESCRIPTION
Adds self-installer/uninstaller options to the keyring unlock script so users no longer need to manually create the password file, set permissions, and configure the GNOME autostart entry.

--install: prompts for the keyring password (or reads from stdin for non-interactive use), creates ~/.pamusb/.keyring_unlock_password (mode 0600), writes the GNOME autostart desktop entry, and adds a user-level gnome-keyring-secrets.desktop override to prevent the system daemon from racing the unlock script.

--uninstall: removes all three files created by --install.

Also adds an integration test and updates the man page and QUICKSTART doc.

Closes #121 