### PR TITLE
#290: Add --install / --uninstall options to pamusb-pinentry

### DIFF
--- a/doc/pamusb-pinentry.1
+++ b/doc/pamusb-pinentry.1
@@ -2,8 +2,20 @@
 
 .SH NAME
 \fBpamusb-pinentry \fP- pam_usb tool to be used as pinentry application
+.SH SYNOPSIS
+\fBpamusb-pinentry\fP [\fB--install\fP | \fB--uninstall\fP]
 .SH DESCRIPTION
 \fBpamusb-pinentry\fP is a tool to unlock your GPG keyring when used with pam_usb autologin.
+When invoked without options it operates as a pinentry program (communicating via the Assuan protocol on stdin/stdout).
+.SH OPTIONS
+.TP
+\fB--install\fP
+Create the envfile (\fI~/.pamusb/.pinentry.env\fP) with a template configuration (permissions 0600) and, if \fBupdate-alternatives\fP(1) is available, register and activate \fBpamusb-pinentry\fP as the system pinentry alternative.
+Must be run as root for the \fBupdate-alternatives\fP step.
+.TP
+\fB--uninstall\fP
+Remove the envfile (\fI~/.pamusb/.pinentry.env\fP) and, if \fBupdate-alternatives\fP(1) is available, deregister the \fBpamusb-pinentry\fP pinentry alternative.
+Must be run as root for the \fBupdate-alternatives\fP step.
 .SH CONFIGURATION
 See the pam_usb Wiki <https://github.com/mcdope/pam_usb/wiki/Getting-Started#auto-unlock-your-gpg-keys> for details about how to configure this feature.
 .SH BUGS

--- a/doc/pamusb-pinentry.1
+++ b/doc/pamusb-pinentry.1
@@ -11,11 +11,13 @@ When invoked without options it operates as a pinentry program (communicating vi
 .TP
 \fB--install\fP
 Create the envfile (\fI~/.pamusb/.pinentry.env\fP) with a template configuration (permissions 0600) and, if \fBupdate-alternatives\fP(1) is available, register and activate \fBpamusb-pinentry\fP as the system pinentry alternative.
-Must be run as root for the \fBupdate-alternatives\fP step.
+The envfile is always created in the invoking user's home directory (using \fBSUDO_USER\fP when run via sudo).
+The \fBupdate-alternatives\fP step requires root privileges.
 .TP
 \fB--uninstall\fP
 Remove the envfile (\fI~/.pamusb/.pinentry.env\fP) and, if \fBupdate-alternatives\fP(1) is available, deregister the \fBpamusb-pinentry\fP pinentry alternative.
-Must be run as root for the \fBupdate-alternatives\fP step.
+The envfile path is resolved via \fBSUDO_USER\fP when run via sudo.
+The \fBupdate-alternatives\fP step requires root privileges.
 .SH CONFIGURATION
 See the pam_usb Wiki <https://github.com/mcdope/pam_usb/wiki/Getting-Started#auto-unlock-your-gpg-keys> for details about how to configure this feature.
 .SH BUGS

--- a/tests/unit/python/test_pamusb_pinentry.py
+++ b/tests/unit/python/test_pamusb_pinentry.py
@@ -7,16 +7,47 @@ Security regression coverage:
   M-3: PINENTRY_FALLBACK_APP validation — non-executable file rejected
   M-3: valid executable fallback is invoked
   Happy path: authenticated + password configured → sends "D <password>" response
+
+Installer/uninstaller coverage:
+  install(): creates envfile + directory, sets 0600 permissions
+  install(): skips envfile creation if it already exists
+  install(): skips update-alternatives when not available
+  install(): registers and activates alternative via update-alternatives
+  install(): exits 1 when update-alternatives --install fails
+  install(): exits 1 when update-alternatives --set fails
+  uninstall(): removes envfile when it exists
+  uninstall(): skips removal when envfile is absent
+  uninstall(): skips update-alternatives when not available
+  uninstall(): removes alternative via update-alternatives
+  uninstall(): exits 1 when update-alternatives --remove fails
 """
 
+import importlib.util
+from importlib.machinery import SourceFileLoader
 import os
 import sys
 import stat
 import subprocess
 import io
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, call
 
+
+# ── Module loader ─────────────────────────────────────────────────────────────
+
+def _load_pinentry():
+    """Import tools/pamusb-pinentry as a module without triggering __main__."""
+    script_path = os.path.normpath(
+        os.path.join(os.path.dirname(__file__), "../../../tools/pamusb-pinentry")
+    )
+    loader = SourceFileLoader("pamusb_pinentry", script_path)
+    spec = importlib.util.spec_from_loader("pamusb_pinentry", loader)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
 
 def _auth_failed_run(*args, **kwargs):
     return subprocess.CompletedProcess(args[0], returncode=1, stdout=b"", stderr=b"")
@@ -127,3 +158,188 @@ def test_getpin_returns_password(capsys):
                 print("OK")
 
         assert any(l.startswith("D ") and "supersecret" in l for l in output_lines)
+
+
+# ── install() ─────────────────────────────────────────────────────────────────
+
+def _ok_run(*args, **kwargs):
+    return subprocess.CompletedProcess(args[0], returncode=0, stdout=b"", stderr=b"")
+
+
+def _fail_run(*args, **kwargs):
+    return subprocess.CompletedProcess(args[0], returncode=1, stdout=b"", stderr=b"error msg")
+
+
+def test_install_creates_envfile(tmp_path):
+    """install() creates the envfile and directory, sets 0600 permissions."""
+    mod = _load_pinentry()
+    envfile = tmp_path / ".pamusb" / ".pinentry.env"
+
+    with patch.object(mod, "ENVFILE_PATH", str(envfile)), \
+         patch("shutil.which", return_value=None), \
+         patch("subprocess.run", side_effect=_ok_run):
+        mod.install()
+
+    assert envfile.exists()
+    assert stat.S_IMODE(envfile.stat().st_mode) == 0o600
+
+
+def test_install_skips_existing_envfile(tmp_path, capsys):
+    """install() does not overwrite an existing envfile."""
+    mod = _load_pinentry()
+    envfile = tmp_path / ".pamusb" / ".pinentry.env"
+    envfile.parent.mkdir(parents=True)
+    envfile.write_text("existing content\n")
+    envfile.chmod(0o644)
+
+    with patch.object(mod, "ENVFILE_PATH", str(envfile)), \
+         patch("shutil.which", return_value=None), \
+         patch("subprocess.run", side_effect=_ok_run):
+        mod.install()
+
+    assert envfile.read_text() == "existing content\n"
+    assert "already exists" in capsys.readouterr().out
+
+
+def test_install_skips_update_alternatives_when_unavailable(tmp_path, capsys):
+    """install() skips alternative registration when update-alternatives is absent."""
+    mod = _load_pinentry()
+    envfile = tmp_path / ".pamusb" / ".pinentry.env"
+    run_calls = []
+
+    with patch.object(mod, "ENVFILE_PATH", str(envfile)), \
+         patch("shutil.which", return_value=None), \
+         patch("subprocess.run", side_effect=lambda *a, **kw: run_calls.append(a)):
+        mod.install()
+
+    assert not any("update-alternatives" in str(c) for c in run_calls)
+    assert "not found" in capsys.readouterr().out
+
+
+def test_install_registers_and_activates_alternative(tmp_path):
+    """install() calls update-alternatives --install then --set."""
+    mod = _load_pinentry()
+    envfile = tmp_path / ".pamusb" / ".pinentry.env"
+    run_calls = []
+
+    def recording_run(args, **kwargs):
+        run_calls.append(list(args))
+        return subprocess.CompletedProcess(args, returncode=0, stdout=b"", stderr=b"")
+
+    with patch.object(mod, "ENVFILE_PATH", str(envfile)), \
+         patch("shutil.which", return_value="/usr/bin/update-alternatives"), \
+         patch("subprocess.run", side_effect=recording_run):
+        mod.install()
+
+    assert any("--install" in c for c in run_calls)
+    assert any("--set" in c for c in run_calls)
+
+
+def test_install_exits_on_update_alternatives_install_failure(tmp_path):
+    """install() exits with code 1 when update-alternatives --install fails."""
+    mod = _load_pinentry()
+    envfile = tmp_path / ".pamusb" / ".pinentry.env"
+
+    def failing_on_install(args, **kwargs):
+        if "--install" in args:
+            return subprocess.CompletedProcess(args, returncode=1, stdout=b"", stderr=b"perm denied")
+        return subprocess.CompletedProcess(args, returncode=0, stdout=b"", stderr=b"")
+
+    with patch.object(mod, "ENVFILE_PATH", str(envfile)), \
+         patch("shutil.which", return_value="/usr/bin/update-alternatives"), \
+         patch("subprocess.run", side_effect=failing_on_install):
+        with pytest.raises(SystemExit) as exc:
+            mod.install()
+    assert exc.value.code == 1
+
+
+def test_install_exits_on_update_alternatives_set_failure(tmp_path):
+    """install() exits with code 1 when update-alternatives --set fails."""
+    mod = _load_pinentry()
+    envfile = tmp_path / ".pamusb" / ".pinentry.env"
+
+    def failing_on_set(args, **kwargs):
+        if "--set" in args:
+            return subprocess.CompletedProcess(args, returncode=1, stdout=b"", stderr=b"perm denied")
+        return subprocess.CompletedProcess(args, returncode=0, stdout=b"", stderr=b"")
+
+    with patch.object(mod, "ENVFILE_PATH", str(envfile)), \
+         patch("shutil.which", return_value="/usr/bin/update-alternatives"), \
+         patch("subprocess.run", side_effect=failing_on_set):
+        with pytest.raises(SystemExit) as exc:
+            mod.install()
+    assert exc.value.code == 1
+
+
+# ── uninstall() ───────────────────────────────────────────────────────────────
+
+def test_uninstall_removes_envfile(tmp_path):
+    """uninstall() removes the envfile when it exists."""
+    mod = _load_pinentry()
+    envfile = tmp_path / ".pamusb" / ".pinentry.env"
+    envfile.parent.mkdir(parents=True)
+    envfile.write_text("data\n")
+
+    with patch.object(mod, "ENVFILE_PATH", str(envfile)), \
+         patch("shutil.which", return_value=None):
+        mod.uninstall()
+
+    assert not envfile.exists()
+
+
+def test_uninstall_skips_missing_envfile(tmp_path, capsys):
+    """uninstall() does not error when envfile is absent."""
+    mod = _load_pinentry()
+    envfile = tmp_path / ".pamusb" / ".pinentry.env"
+
+    with patch.object(mod, "ENVFILE_PATH", str(envfile)), \
+         patch("shutil.which", return_value=None):
+        mod.uninstall()
+
+    assert "does not exist" in capsys.readouterr().out
+
+
+def test_uninstall_skips_update_alternatives_when_unavailable(tmp_path, capsys):
+    """uninstall() skips alternative removal when update-alternatives is absent."""
+    mod = _load_pinentry()
+    envfile = tmp_path / ".pamusb" / ".pinentry.env"
+    run_calls = []
+
+    with patch.object(mod, "ENVFILE_PATH", str(envfile)), \
+         patch("shutil.which", return_value=None), \
+         patch("subprocess.run", side_effect=lambda *a, **kw: run_calls.append(a)):
+        mod.uninstall()
+
+    assert not any("update-alternatives" in str(c) for c in run_calls)
+    assert "not found" in capsys.readouterr().out
+
+
+def test_uninstall_removes_alternative(tmp_path):
+    """uninstall() calls update-alternatives --remove."""
+    mod = _load_pinentry()
+    envfile = tmp_path / ".pamusb" / ".pinentry.env"
+    run_calls = []
+
+    def recording_run(args, **kwargs):
+        run_calls.append(list(args))
+        return subprocess.CompletedProcess(args, returncode=0, stdout=b"", stderr=b"")
+
+    with patch.object(mod, "ENVFILE_PATH", str(envfile)), \
+         patch("shutil.which", return_value="/usr/bin/update-alternatives"), \
+         patch("subprocess.run", side_effect=recording_run):
+        mod.uninstall()
+
+    assert any("--remove" in c for c in run_calls)
+
+
+def test_uninstall_exits_on_update_alternatives_failure(tmp_path):
+    """uninstall() exits with code 1 when update-alternatives --remove fails."""
+    mod = _load_pinentry()
+    envfile = tmp_path / ".pamusb" / ".pinentry.env"
+
+    with patch.object(mod, "ENVFILE_PATH", str(envfile)), \
+         patch("shutil.which", return_value="/usr/bin/update-alternatives"), \
+         patch("subprocess.run", side_effect=_fail_run):
+        with pytest.raises(SystemExit) as exc:
+            mod.uninstall()
+    assert exc.value.code == 1

--- a/tests/unit/python/test_pamusb_pinentry.py
+++ b/tests/unit/python/test_pamusb_pinentry.py
@@ -8,6 +8,10 @@ Security regression coverage:
   M-3: valid executable fallback is invoked
   Happy path: authenticated + password configured → sends "D <password>" response
 
+_user_home() coverage:
+  returns SUDO_USER home when running as root via sudo
+  returns current user home when not running as root
+
 Installer/uninstaller coverage:
   install(): creates envfile + directory, sets 0600 permissions
   install(): skips envfile creation if it already exists
@@ -158,6 +162,34 @@ def test_getpin_returns_password(capsys):
                 print("OK")
 
         assert any(l.startswith("D ") and "supersecret" in l for l in output_lines)
+
+
+# ── _user_home() ──────────────────────────────────────────────────────────────
+
+def test_user_home_uses_sudo_user_when_root(tmp_path):
+    """_user_home() returns SUDO_USER's home dir when euid == 0."""
+    import pwd as _pwd
+    mod = _load_pinentry()
+    fake_home = str(tmp_path / "regularuser")
+    fake_entry = _pwd.struct_passwd(("regularuser", "x", 1000, 1000, "", fake_home, "/bin/bash"))
+
+    with patch.dict(os.environ, {"SUDO_USER": "regularuser"}, clear=False), \
+         patch("os.geteuid", return_value=0), \
+         patch("pwd.getpwnam", return_value=fake_entry):
+        result = mod._user_home()
+
+    assert result == fake_home
+
+
+def test_user_home_uses_expanduser_when_not_root(monkeypatch):
+    """_user_home() falls back to expanduser('~') when not running as root."""
+    mod = _load_pinentry()
+    monkeypatch.delenv("SUDO_USER", raising=False)
+
+    with patch("os.geteuid", return_value=1000):
+        result = mod._user_home()
+
+    assert result == os.path.expanduser("~")
 
 
 # ── install() ─────────────────────────────────────────────────────────────────

--- a/tools/pamusb-pinentry
+++ b/tools/pamusb-pinentry
@@ -19,25 +19,125 @@ import os
 import sys
 import subprocess
 import getpass
+import argparse
+import shutil
 from dotenv import load_dotenv
-load_dotenv(os.path.expanduser("~/.pamusb/.pinentry.env"))
 
-pinentryPassword = os.getenv('PINENTRY_PASSWORD')
-fallbackPinentryApp = os.getenv('PINENTRY_FALLBACK_APP')
+ENVFILE_PATH = os.path.expanduser("~/.pamusb/.pinentry.env")
+PINENTRY_LINK = "/usr/bin/pinentry"
+PINENTRY_ALT_NAME = "pinentry"
+PAMUSB_PINENTRY_PATH = "/usr/bin/pamusb-pinentry"
+PINENTRY_ALT_PRIORITY = 100
 
-isAuthenticated = subprocess.run(["pamusb-check", getpass.getuser()], capture_output=True)
-if (isAuthenticated.returncode == 0):
-    print("OK Pleased to meet you")
-    while True:
-        line = input().split()
-        if line[0] == "GETPIN":
-            print("D %s" % pinentryPassword)
-        elif line[0] == "BYE":
-            exit()
-        print("OK")
-else:
-    if fallbackPinentryApp and os.path.isabs(fallbackPinentryApp) and os.path.isfile(fallbackPinentryApp) and os.access(fallbackPinentryApp, os.X_OK):
-        subprocess.run([fallbackPinentryApp])
+ENVFILE_TEMPLATE = (
+    "# pamusb-pinentry configuration\n"
+    "# Your GPG passphrase for auto-unlock\n"
+    "PINENTRY_PASSWORD=changeme\n"
+    "\n"
+    "# Fallback pinentry application (must be an absolute path)\n"
+    "# PINENTRY_FALLBACK_APP=/usr/bin/pinentry-gnome3\n"
+)
+
+
+def install():
+    envfile_dir = os.path.dirname(ENVFILE_PATH)
+    os.makedirs(envfile_dir, exist_ok=True)
+
+    if not os.path.exists(ENVFILE_PATH):
+        with open(ENVFILE_PATH, 'w') as f:
+            f.write(ENVFILE_TEMPLATE)
+        os.chmod(ENVFILE_PATH, 0o600)
+        print("Created %s" % ENVFILE_PATH)
     else:
-        sys.stderr.write('PINENTRY_FALLBACK_APP is not set or not a valid executable path, cannot fall back.\n')
+        print("%s already exists, skipping creation." % ENVFILE_PATH)
+
+    if shutil.which("update-alternatives") is None:
+        print("update-alternatives not found, skipping alternative registration.")
+        return
+
+    result = subprocess.run(
+        ["update-alternatives", "--install", PINENTRY_LINK, PINENTRY_ALT_NAME,
+         PAMUSB_PINENTRY_PATH, str(PINENTRY_ALT_PRIORITY)],
+        capture_output=True
+    )
+    if result.returncode != 0:
+        sys.stderr.write("Failed to register alternative: %s\n" % result.stderr.decode())
         sys.exit(1)
+
+    result = subprocess.run(
+        ["update-alternatives", "--set", PINENTRY_ALT_NAME, PAMUSB_PINENTRY_PATH],
+        capture_output=True
+    )
+    if result.returncode != 0:
+        sys.stderr.write("Failed to activate alternative: %s\n" % result.stderr.decode())
+        sys.exit(1)
+
+    print("pamusb-pinentry registered and activated as pinentry alternative.")
+
+
+def uninstall():
+    if os.path.exists(ENVFILE_PATH):
+        os.remove(ENVFILE_PATH)
+        print("Removed %s" % ENVFILE_PATH)
+    else:
+        print("%s does not exist, skipping removal." % ENVFILE_PATH)
+
+    if shutil.which("update-alternatives") is None:
+        print("update-alternatives not found, skipping alternative removal.")
+        return
+
+    result = subprocess.run(
+        ["update-alternatives", "--remove", PINENTRY_ALT_NAME, PAMUSB_PINENTRY_PATH],
+        capture_output=True
+    )
+    if result.returncode != 0:
+        sys.stderr.write("Failed to remove alternative: %s\n" % result.stderr.decode())
+        sys.exit(1)
+
+    print("pamusb-pinentry alternative removed.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="pam_usb pinentry tool"
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--install", action="store_true",
+        help="Create envfile and register pamusb-pinentry as pinentry alternative"
+    )
+    group.add_argument(
+        "--uninstall", action="store_true",
+        help="Remove envfile and unregister pamusb-pinentry pinentry alternative"
+    )
+    args = parser.parse_args()
+
+    if args.install:
+        install()
+        sys.exit(0)
+
+    if args.uninstall:
+        uninstall()
+        sys.exit(0)
+
+    load_dotenv(ENVFILE_PATH)
+
+    pinentryPassword = os.getenv('PINENTRY_PASSWORD')
+    fallbackPinentryApp = os.getenv('PINENTRY_FALLBACK_APP')
+
+    isAuthenticated = subprocess.run(["pamusb-check", getpass.getuser()], capture_output=True)
+    if (isAuthenticated.returncode == 0):
+        print("OK Pleased to meet you")
+        while True:
+            line = input().split()
+            if line[0] == "GETPIN":
+                print("D %s" % pinentryPassword)
+            elif line[0] == "BYE":
+                exit()
+            print("OK")
+    else:
+        if fallbackPinentryApp and os.path.isabs(fallbackPinentryApp) and os.path.isfile(fallbackPinentryApp) and os.access(fallbackPinentryApp, os.X_OK):
+            subprocess.run([fallbackPinentryApp])
+        else:
+            sys.stderr.write('PINENTRY_FALLBACK_APP is not set or not a valid executable path, cannot fall back.\n')
+            sys.exit(1)

--- a/tools/pamusb-pinentry
+++ b/tools/pamusb-pinentry
@@ -21,9 +21,19 @@ import subprocess
 import getpass
 import argparse
 import shutil
+import pwd
 from dotenv import load_dotenv
 
-ENVFILE_PATH = os.path.expanduser("~/.pamusb/.pinentry.env")
+
+def _user_home():
+    """Return the real user's home directory, even when invoked via sudo."""
+    sudo_user = os.environ.get("SUDO_USER")
+    if sudo_user and os.geteuid() == 0:
+        return pwd.getpwnam(sudo_user).pw_dir
+    return os.path.expanduser("~")
+
+
+ENVFILE_PATH = os.path.join(_user_home(), ".pamusb", ".pinentry.env")
 PINENTRY_LINK = "/usr/bin/pinentry"
 PINENTRY_ALT_NAME = "pinentry"
 PAMUSB_PINENTRY_PATH = "/usr/bin/pamusb-pinentry"


### PR DESCRIPTION
## Summary

- Adds `--install` to `pamusb-pinentry`: creates `~/.pamusb/.pinentry.env` (mode 0600, skips if already present) and, when `update-alternatives` is on `$PATH`, registers and activates `pamusb-pinentry` as the system `pinentry` alternative
- Adds `--uninstall`: removes the envfile and deregisters the `update-alternatives` entry
- Wraps former module-level execution in `if __name__ == "__main__":` so `install()`/`uninstall()` are importable and testable without side effects
- Updates man page with `SYNOPSIS` and `OPTIONS` sections
- Adds 11 new unit tests covering all branches of both functions

## Test plan

- [ ] `python3 -m pytest tests/unit/python/test_pamusb_pinentry.py -v` — all 16 tests pass
- [ ] `pamusb-pinentry --help` shows `--install` / `--uninstall` options
- [ ] `sudo pamusb-pinentry --install` creates `~/.pamusb/.pinentry.env` with 0600 perms and registers the alternative
- [ ] `sudo pamusb-pinentry --uninstall` removes the envfile and deregisters the alternative
- [ ] Running `pamusb-pinentry` without flags behaves identically to before (pinentry protocol)

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)