### PR TITLE
Harden utmp display session matching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ PAD_LDFLAGS              := `pkg-config --libs libxml-2.0` -lcmocka
 PROC_LDFLAGS             := -lcmocka
 RMSVC_LDFLAGS            := -lcmocka
 EVDEV_LDFLAGS            := -lcmocka
+LOCAL_LDFLAGS            := `pkg-config --libs libevdev` -lcmocka
 
 test-c-xpath: src/xpath.o src/mem.o src/log.o
 	$(CC) $(TEST_CFLAGS) tests/unit/c/xpath_test.c $^ $(XPATH_LDFLAGS) -o tests/unit/c/xpath_test
@@ -139,6 +140,11 @@ test-c-rmsvc: src/mem.o src/log.o
 		$(RMSVC_LDFLAGS) -o tests/unit/c/rmsvc_test
 	./tests/unit/c/rmsvc_test
 
+test-c-local: src/process.o src/tmux.o src/rmsvc.o src/evdev.o src/mem.o src/log.o
+	$(CC) $(TEST_CFLAGS) tests/unit/c/local_test.c $^ \
+		$(LOCAL_LDFLAGS) -o tests/unit/c/local_test
+	./tests/unit/c/local_test
+
 test-c-evdev: src/mem.o src/log.o
 	$(CC) $(TEST_CFLAGS) tests/unit/c/evdev_test.c \
 		tests/unit/c/fake_libevdev.c $^ \
@@ -146,7 +152,7 @@ test-c-evdev: src/mem.o src/log.o
 		$(EVDEV_LDFLAGS) -o tests/unit/c/evdev_test
 	./tests/unit/c/evdev_test
 
-test-c: test-c-xpath test-c-conf test-c-tmux test-c-pad test-c-process test-c-rmsvc test-c-evdev
+test-c: test-c-xpath test-c-conf test-c-tmux test-c-pad test-c-process test-c-rmsvc test-c-local test-c-evdev
 
 test-python:
 	python3 -m pytest tests/unit/python/ -v

--- a/src/local.c
+++ b/src/local.c
@@ -34,6 +34,54 @@
 #include "rmsvc.h"
 #include "evdev.h"
 
+static size_t pusb_bounded_strlen(const char *value, size_t max_len)
+{
+	size_t len = 0;
+
+	while (len < max_len && value[len] != '\0')
+	{
+		len++;
+	}
+
+	return len;
+}
+
+static int pusb_utmpx_field_equals(const char *field, size_t field_len, const char *value)
+{
+	size_t value_len;
+
+	if (field == NULL || value == NULL)
+	{
+		return 0;
+	}
+
+	value_len = pusb_bounded_strlen(value, field_len + 1);
+	if (value_len > field_len)
+	{
+		return 0;
+	}
+
+	if (memcmp(field, value, value_len) != 0)
+	{
+		return 0;
+	}
+
+	return value_len == field_len || field[value_len] == '\0';
+}
+
+static int pusb_utmpx_field_starts_with(const char *field, size_t field_len, const char *prefix)
+{
+	size_t prefix_len;
+
+	if (field == NULL || prefix == NULL)
+	{
+		return 0;
+	}
+
+	prefix_len = pusb_bounded_strlen(prefix, field_len + 1);
+	return prefix_len <= field_len && memcmp(field, prefix, prefix_len) == 0;
+}
+
 int pusb_is_tty_local(char *tty)
 {
 	struct utmpx utsearch;
@@ -181,12 +229,12 @@ char *pusb_get_tty_by_xorg_display(const char *display, const char *user)
 	setutxent();
 	while ((utent = getutxent())) 
 	{
-		if (strncmp(utent->ut_host, display, strlen(display)) == 0
-			&& strncmp(utent->ut_user, user, strlen(user)) == 0
+		if (pusb_utmpx_field_equals(utent->ut_host, sizeof(utent->ut_host), display)
+			&& pusb_utmpx_field_equals(utent->ut_user, sizeof(utent->ut_user), user)
 			&& (
-				strncmp(utent->ut_line, "tty", sizeof(utent->ut_line)) == 0
-				|| strncmp(utent->ut_line, "console", sizeof(utent->ut_line)) == 0
-				|| strncmp(utent->ut_line, "pts", sizeof(utent->ut_line)) == 0
+				pusb_utmpx_field_starts_with(utent->ut_line, sizeof(utent->ut_line), "tty")
+				|| pusb_utmpx_field_starts_with(utent->ut_line, sizeof(utent->ut_line), "console")
+				|| pusb_utmpx_field_starts_with(utent->ut_line, sizeof(utent->ut_line), "pts")
 			)
 		)
 		{
@@ -201,7 +249,7 @@ char *pusb_get_tty_by_xorg_display(const char *display, const char *user)
 
 char *pusb_get_tty_by_loginctl()
 {
-	char loginctl_cmd[BUFSIZ] = "LC_ALL=C; LOGINCTL_SESSION_ID=`loginctl user-status | grep -m 1  \"├─session-\" | grep -o '[0-9]\\+'`; loginctl show-session $LOGINCTL_SESSION_ID -p TTY | awk -F= '{print $2}'";
+	char loginctl_cmd[BUFSIZ] = "LC_ALL=C; LOGINCTL_SESSION_ID=`/usr/bin/loginctl user-status | /usr/bin/grep -m 1  \"├─session-\" | /usr/bin/grep -o '[0-9]\\+'`; /usr/bin/loginctl show-session $LOGINCTL_SESSION_ID -p TTY | /usr/bin/awk -F= '{print $2}'";
 	char buf[BUFSIZ];
 	FILE *fp;
 
@@ -238,7 +286,7 @@ char *pusb_get_tty_by_loginctl()
 
 int pusb_is_loginctl_local()
 {
-	char loginctl_cmd[BUFSIZ] = "LC_ALL=C; LOGINCTL_SESSION_ID=`loginctl user-status | grep -m 1  \"├─session-\" | grep -o '[0-9]\\+'`; loginctl show-session $LOGINCTL_SESSION_ID -p Remote | awk -F= '{print $2}'";
+	char loginctl_cmd[BUFSIZ] = "LC_ALL=C; LOGINCTL_SESSION_ID=`/usr/bin/loginctl user-status | /usr/bin/grep -m 1  \"├─session-\" | /usr/bin/grep -o '[0-9]\\+'`; /usr/bin/loginctl show-session $LOGINCTL_SESSION_ID -p Remote | /usr/bin/awk -F= '{print $2}'";
 	char buf[BUFSIZ];
 	FILE *fp;
 

--- a/src/local.c
+++ b/src/local.c
@@ -34,18 +34,6 @@
 #include "rmsvc.h"
 #include "evdev.h"
 
-static size_t pusb_bounded_strlen(const char *value, size_t max_len)
-{
-	size_t len = 0;
-
-	while (len < max_len && value[len] != '\0')
-	{
-		len++;
-	}
-
-	return len;
-}
-
 static int pusb_utmpx_field_equals(const char *field, size_t field_len, const char *value)
 {
 	size_t value_len;
@@ -55,7 +43,7 @@ static int pusb_utmpx_field_equals(const char *field, size_t field_len, const ch
 		return 0;
 	}
 
-	value_len = pusb_bounded_strlen(value, field_len + 1);
+	value_len = strnlen(value, field_len + 1);
 	if (value_len > field_len)
 	{
 		return 0;
@@ -78,7 +66,7 @@ static int pusb_utmpx_field_starts_with(const char *field, size_t field_len, con
 		return 0;
 	}
 
-	prefix_len = pusb_bounded_strlen(prefix, field_len + 1);
+	prefix_len = strlen(prefix);
 	return prefix_len <= field_len && memcmp(field, prefix, prefix_len) == 0;
 }
 

--- a/tests/unit/c/local_test.c
+++ b/tests/unit/c/local_test.c
@@ -22,6 +22,16 @@ static void test_utmpx_field_equals_exact_nul_padded(void **state)
 	assert_int_equal(1, pusb_utmpx_field_equals(field, sizeof(field), "alice"));
 }
 
+static void test_utmpx_field_equals_rejects_null_input(void **state)
+{
+	(void)state;
+	char field[8] = {0};
+	snprintf(field, sizeof(field), "%s", "alice");
+
+	assert_int_equal(0, pusb_utmpx_field_equals(NULL, sizeof(field), "alice"));
+	assert_int_equal(0, pusb_utmpx_field_equals(field, sizeof(field), NULL));
+}
+
 static void test_utmpx_field_equals_rejects_prefix_match(void **state)
 {
 	(void)state;
@@ -29,6 +39,14 @@ static void test_utmpx_field_equals_rejects_prefix_match(void **state)
 	snprintf(field, sizeof(field), "%s", "alice2");
 
 	assert_int_equal(0, pusb_utmpx_field_equals(field, sizeof(field), "alice"));
+}
+
+static void test_utmpx_field_equals_rejects_value_longer_than_field(void **state)
+{
+	(void)state;
+	char field[5] = {'a', 'l', 'i', 'c', 'e'};
+
+	assert_int_equal(0, pusb_utmpx_field_equals(field, sizeof(field), "alice2"));
 }
 
 static void test_utmpx_field_equals_full_width_field(void **state)
@@ -49,6 +67,16 @@ static void test_utmpx_field_starts_with_tty_number(void **state)
 	assert_int_equal(1, pusb_utmpx_field_starts_with(field, sizeof(field), "tty"));
 }
 
+static void test_utmpx_field_starts_with_rejects_null_input(void **state)
+{
+	(void)state;
+	char field[8] = {0};
+	snprintf(field, sizeof(field), "%s", "tty1");
+
+	assert_int_equal(0, pusb_utmpx_field_starts_with(NULL, sizeof(field), "tty"));
+	assert_int_equal(0, pusb_utmpx_field_starts_with(field, sizeof(field), NULL));
+}
+
 static void test_utmpx_field_starts_with_pts_slave(void **state)
 {
 	(void)state;
@@ -56,6 +84,14 @@ static void test_utmpx_field_starts_with_pts_slave(void **state)
 	snprintf(field, sizeof(field), "%s", "pts/0");
 
 	assert_int_equal(1, pusb_utmpx_field_starts_with(field, sizeof(field), "pts"));
+}
+
+static void test_utmpx_field_starts_with_full_width_field(void **state)
+{
+	(void)state;
+	char field[3] = {'t', 't', 'y'};
+
+	assert_int_equal(1, pusb_utmpx_field_starts_with(field, sizeof(field), "tty"));
 }
 
 static void test_utmpx_field_starts_with_rejects_long_prefix(void **state)
@@ -70,10 +106,14 @@ int main(void)
 {
 	const struct CMUnitTest tests[] = {
 		cmocka_unit_test(test_utmpx_field_equals_exact_nul_padded),
+		cmocka_unit_test(test_utmpx_field_equals_rejects_null_input),
 		cmocka_unit_test(test_utmpx_field_equals_rejects_prefix_match),
+		cmocka_unit_test(test_utmpx_field_equals_rejects_value_longer_than_field),
 		cmocka_unit_test(test_utmpx_field_equals_full_width_field),
 		cmocka_unit_test(test_utmpx_field_starts_with_tty_number),
+		cmocka_unit_test(test_utmpx_field_starts_with_rejects_null_input),
 		cmocka_unit_test(test_utmpx_field_starts_with_pts_slave),
+		cmocka_unit_test(test_utmpx_field_starts_with_full_width_field),
 		cmocka_unit_test(test_utmpx_field_starts_with_rejects_long_prefix),
 	};
 	return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/unit/c/local_test.c
+++ b/tests/unit/c/local_test.c
@@ -1,0 +1,80 @@
+/*
+ * Unit tests for src/local.c.
+ * Include the source directly to cover static helpers used with fixed-size
+ * utmpx fields.
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <string.h>
+#include <cmocka.h>
+
+/* Include source directly to access static helper functions. */
+#include "../../../src/local.c"
+
+static void test_utmpx_field_equals_exact_nul_padded(void **state)
+{
+	(void)state;
+	char field[8] = {0};
+	snprintf(field, sizeof(field), "%s", "alice");
+
+	assert_int_equal(1, pusb_utmpx_field_equals(field, sizeof(field), "alice"));
+}
+
+static void test_utmpx_field_equals_rejects_prefix_match(void **state)
+{
+	(void)state;
+	char field[8] = {0};
+	snprintf(field, sizeof(field), "%s", "alice2");
+
+	assert_int_equal(0, pusb_utmpx_field_equals(field, sizeof(field), "alice"));
+}
+
+static void test_utmpx_field_equals_full_width_field(void **state)
+{
+	(void)state;
+	char field[5] = {'a', 'l', 'i', 'c', 'e'};
+
+	assert_int_equal(1, pusb_utmpx_field_equals(field, sizeof(field), "alice"));
+	assert_int_equal(0, pusb_utmpx_field_equals(field, sizeof(field), "ali"));
+}
+
+static void test_utmpx_field_starts_with_tty_number(void **state)
+{
+	(void)state;
+	char field[8] = {0};
+	snprintf(field, sizeof(field), "%s", "tty1");
+
+	assert_int_equal(1, pusb_utmpx_field_starts_with(field, sizeof(field), "tty"));
+}
+
+static void test_utmpx_field_starts_with_pts_slave(void **state)
+{
+	(void)state;
+	char field[8] = {0};
+	snprintf(field, sizeof(field), "%s", "pts/0");
+
+	assert_int_equal(1, pusb_utmpx_field_starts_with(field, sizeof(field), "pts"));
+}
+
+static void test_utmpx_field_starts_with_rejects_long_prefix(void **state)
+{
+	(void)state;
+	char field[3] = {'p', 't', 's'};
+
+	assert_int_equal(0, pusb_utmpx_field_starts_with(field, sizeof(field), "pts/"));
+}
+
+int main(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_utmpx_field_equals_exact_nul_padded),
+		cmocka_unit_test(test_utmpx_field_equals_rejects_prefix_match),
+		cmocka_unit_test(test_utmpx_field_equals_full_width_field),
+		cmocka_unit_test(test_utmpx_field_starts_with_tty_number),
+		cmocka_unit_test(test_utmpx_field_starts_with_pts_slave),
+		cmocka_unit_test(test_utmpx_field_starts_with_rejects_long_prefix),
+	};
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
## Summary
- add fixed-width utmpx field helpers so user/display comparisons are exact instead of prefix-based
- keep `tty*`, `pts*`, and `console*` line matching as intentional prefix checks
- use absolute paths for the `loginctl`/`grep`/`awk` calls executed from PAM's local-session fallback
- add regression coverage for prefix rejection and common `tty1` / `pts/0` utmp lines

## Security note
The previous `pusb_get_tty_by_xorg_display()` path could treat a shorter PAM user or display value as matching a longer utmp field. It also compared `ut_line` against `"tty"`, `"console"`, and `"pts"` using the full utmp field width, which rejects common values like `tty1` and `pts/0`.

The `loginctl` fallback already checks for `/usr/bin/loginctl`, but the command string still resolved `loginctl`, `grep`, and `awk` through `PATH`; this patch keeps those helper calls absolute.

This was prepared as an AI-assisted audit pass from the `nexiumbiz-debug` account.

## Testing
- `git diff --check`
- Not run locally: current environment is Windows and has neither Docker nor an installed WSL distro for the Linux/PAM build dependencies.

Related to #55.