### PR TITLE
Validate tmux client tty path

### DIFF
--- a/src/tmux.c
+++ b/src/tmux.c
@@ -127,6 +127,12 @@ char *pusb_tmux_get_client_tty(pid_t env_pid)
             pclose(fp);
             return NULL;
         }
+        if (strncmp(tmux_client_tty, "/dev/", 5) != 0)
+        {
+            log_error("tmux detected, but client tty is not under /dev. Denying.\n");
+            pclose(fp);
+            return NULL;
+        }
         tmux_client_tty += 5; // cut "/dev/"
         log_debug("		Got tmux_client_tty: %s\n", tmux_client_tty);
 

--- a/tests/unit/c/tmux_test.c
+++ b/tests/unit/c/tmux_test.c
@@ -225,6 +225,16 @@ static void test_get_client_tty_valid(void **state)
 	unsetenv("TMUX");
 }
 
+static void test_get_client_tty_rejects_non_dev_tty(void **state)
+{
+	(void)state;
+	setenv("TMUX", "/tmp/tmux-1000/default,abc,42", 1);
+	g_popen_output = "pts/1: session info\n";
+	char *result = pusb_tmux_get_client_tty(0);
+	assert_null(result);
+	unsetenv("TMUX");
+}
+
 /* ── main ── */
 
 int main(void)
@@ -258,6 +268,7 @@ int main(void)
 		cmocka_unit_test(test_get_client_tty_injection_semicolon),
 		cmocka_unit_test(test_get_client_tty_nonnumeric_id),
 		cmocka_unit_test(test_get_client_tty_valid),
+		cmocka_unit_test(test_get_client_tty_rejects_non_dev_tty),
 	};
 	return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
## Summary
- reject `tmux list-clients` results that do not begin with `/dev/` before stripping the prefix
- add a regression test for malformed tmux client tty output

Refs #55

## Testing
- `gcc -D_UTSNAME_NODENAME_LENGTH=65 -fsyntax-only -Wall -I src src/tmux.c`
- `git diff --check`

`make test-c-tmux` was attempted but this macOS environment lacks `pkg-config` and the Linux/PAM headers/constants needed by the project test target.