### PR TITLE
Harden tmux command lookup

### DIFF
--- a/src/tmux.c
+++ b/src/tmux.c
@@ -102,9 +102,13 @@ char *pusb_tmux_get_client_tty(pid_t env_pid)
         return NULL;
     }
 
-    size_t get_tmux_session_details_cmd_len = strlen(tmux_socket_path) + strlen(tmux_client_id) + 64;
+    size_t get_tmux_session_details_cmd_len =
+        strlen("LC_ALL=C; /usr/bin/tmux -S \"\" list-clients -t \"\\$\"")
+        + strlen(tmux_socket_path)
+        + strlen(tmux_client_id)
+        + 1;
     char *get_tmux_session_details_cmd = xmalloc(get_tmux_session_details_cmd_len);
-    snprintf(get_tmux_session_details_cmd, get_tmux_session_details_cmd_len, "LC_ALL=C; tmux -S \"%s\" list-clients -t \"\\$%s\"", tmux_socket_path, tmux_client_id);
+    snprintf(get_tmux_session_details_cmd, get_tmux_session_details_cmd_len, "LC_ALL=C; /usr/bin/tmux -S \"%s\" list-clients -t \"\\$%s\"", tmux_socket_path, tmux_client_id);
     log_debug("		Built get_tmux_session_details_cmd: %s\n", get_tmux_session_details_cmd);
 
     char buf[BUFSIZ];

--- a/tests/unit/c/tmux_test.c
+++ b/tests/unit/c/tmux_test.c
@@ -8,6 +8,7 @@
  *   C-1: non-numeric TMUX client ID rejected
  *   C-1: pusb_tmux_escape_for_regex handles all 14 ERE metacharacters
  *   C-1: dot in username escaped so it doesn't match a different user
+ *   C-2: tmux command is resolved by absolute path, not PAM-time PATH
  */
 
 #include <stdarg.h>
@@ -25,10 +26,11 @@
 /* ── popen/pclose mock ── */
 
 static const char *g_popen_output = "";
+static char g_last_popen_cmd[BUFSIZ];
 
 FILE *__wrap_popen(const char *cmd, const char *type)
 {
-	(void)cmd;
+	snprintf(g_last_popen_cmd, sizeof(g_last_popen_cmd), "%s", cmd);
 	return fmemopen((void *)g_popen_output, strlen(g_popen_output), type);
 }
 
@@ -225,6 +227,22 @@ static void test_get_client_tty_valid(void **state)
 	unsetenv("TMUX");
 }
 
+static void test_get_client_tty_uses_absolute_tmux_path(void **state)
+{
+	(void)state;
+	setenv("TMUX", "/tmp/tmux-1000/default,abc,42", 1);
+	g_popen_output = "/dev/pts/1: session info\n";
+	memset(g_last_popen_cmd, 0, sizeof(g_last_popen_cmd));
+
+	char *result = pusb_tmux_get_client_tty(0);
+
+	assert_non_null(result);
+	assert_non_null(strstr(g_last_popen_cmd, "LC_ALL=C; /usr/bin/tmux -S "));
+	assert_null(strstr(g_last_popen_cmd, "LC_ALL=C; tmux -S "));
+	free(result);
+	unsetenv("TMUX");
+}
+
 /* ── main ── */
 
 int main(void)
@@ -258,6 +276,7 @@ int main(void)
 		cmocka_unit_test(test_get_client_tty_injection_semicolon),
 		cmocka_unit_test(test_get_client_tty_nonnumeric_id),
 		cmocka_unit_test(test_get_client_tty_valid),
+		cmocka_unit_test(test_get_client_tty_uses_absolute_tmux_path),
 	};
 	return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
## Summary
- resolve the tmux client lookup through `/usr/bin/tmux` instead of `PATH`
- size the command buffer from the exact command literal instead of a loose constant
- add regression coverage that records the mocked `popen()` command and checks the absolute tmux path is used

## Security note
`pusb_tmux_get_client_tty()` runs during the local/remote PAM decision path and shells out through `popen()`. The socket path and client id are already validated, but the command itself still resolved `tmux` via the caller's `PATH`. If this code runs under a PAM/sudo context with a user-influenced `PATH`, a user-writable `tmux` earlier in that path can be executed before the remote-locality decision completes.

This is the same class of hardening as the absolute `loginctl` / `grep` / `awk` command paths from #306, but scoped to the tmux fallback. It is separate from #309, which validates the tty value returned by `tmux list-clients`.

This was prepared as an AI-assisted follow-up audit pass from the `dicnunz` account.

## Testing
- `gcc -D_UTSNAME_NODENAME_LENGTH=65 -fsyntax-only -Wall -I src src/tmux.c`
- `git diff --check`

Not fully run locally:
- `make test-c-tmux` starts but this macOS environment is missing the Linux pkg-config deps (`udisks2`, `libevdev`) and `_UTSNAME_NODENAME_LENGTH` definition used by the project test target.
- direct `tests/unit/c/tmux_test.c` syntax check is blocked by missing `cmocka.h` locally.

Related to #55.
