### PR TITLE
Reject unsafe config XPath ids

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -23,6 +23,28 @@
 #include "xpath.h"
 #include "log.h"
 
+static int pusb_conf_xpath_id_is_safe(const char *name, const char *value)
+{
+	const unsigned char *cursor;
+
+	if (value == NULL || value[0] == '\0')
+	{
+		log_error("%s is empty.\n", name);
+		return 0;
+	}
+
+	for (cursor = (const unsigned char *)value; *cursor != '\0'; ++cursor)
+	{
+		if (*cursor == '\'' || *cursor < 0x20)
+		{
+			log_error("%s contains an unsafe character for XPath lookup.\n", name);
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
 static void pusb_conf_options_get_from(
 	t_pusb_options *opts,
 	const char *from,
@@ -55,16 +77,10 @@ static int pusb_conf_parse_options(
 	size_t xpath_size;
 	int i;
 
-	// these can come from argv, so make sure nothing messes up snprintf later
-	char xpath_user[32] = { };
-	char xpath_service[32] = { };
-	snprintf(xpath_user, sizeof(xpath_user), "%s", user);
-	snprintf(xpath_service, sizeof(xpath_service), "%s", service);
-
 	struct s_opt_list opt_list[] = {
 		{ CONF_DEVICE_XPATH, opts->device.name },
-		{ CONF_USER_XPATH, xpath_user },
-		{ CONF_SERVICE_XPATH, xpath_service },
+		{ CONF_USER_XPATH, user },
+		{ CONF_SERVICE_XPATH, service },
 		{ NULL, NULL }
 	};
 
@@ -118,6 +134,11 @@ static int pusb_conf_parse_device(
 	char *deviceId
 )
 {
+	if (!pusb_conf_xpath_id_is_safe("Device id", deviceId))
+	{
+		return 0;
+	}
+
 	pusb_conf_device_get_property(opts, doc, "vendor", opts->device_list[deviceIndex].vendor, sizeof(opts->device_list[deviceIndex].vendor), deviceId);
 	pusb_conf_device_get_property(opts, doc, "model", opts->device_list[deviceIndex].model, sizeof(opts->device_list[deviceIndex].model), deviceId);
 
@@ -172,6 +193,11 @@ int pusb_conf_parse(
 	char device_xpath[sizeof(CONF_USER_XPATH) + CONF_USER_MAXLEN + sizeof("device")];
 
 	log_debug("Parsing settings...\n", user, service);
+	if (!pusb_conf_xpath_id_is_safe("Username", user) ||
+	    !pusb_conf_xpath_id_is_safe("Service", service))
+	{
+		return 0;
+	}
 	if (strlen(user) > CONF_USER_MAXLEN)
 	{
 		log_error("Username \"%s\" is too long (max: %d).\n", user, CONF_USER_MAXLEN);
@@ -220,7 +246,17 @@ int pusb_conf_parse(
 		}
 
 		snprintf(opts->device_list[currentDevice].name, sizeof(opts->device_list[currentDevice].name), "%s", device_list[currentDevice]);
-		pusb_conf_parse_device(opts, doc, currentDevice, device_list[currentDevice]);
+		if (!pusb_conf_parse_device(opts, doc, currentDevice, device_list[currentDevice]))
+		{
+			xmlFreeDoc(doc);
+			xmlCleanupParser();
+
+			for (int i = 0; i < 10; i++)
+			{
+				xfree(device_list[i]);
+			}
+			return 0;
+		}
 	}
 
 	/* Mark devices that carry superuser="true" in the user's <device> elements. */

--- a/src/conf.h
+++ b/src/conf.h
@@ -65,8 +65,8 @@ typedef struct		pusb_options
 
 struct		s_opt_list
 {
-	char	*name;
-	char	*value;
+	const char	*name;
+	const char	*value;
 };
 
 int pusb_conf_init(t_pusb_options *opts);

--- a/tests/unit/c/conf_test.c
+++ b/tests/unit/c/conf_test.c
@@ -154,6 +154,53 @@ static void test_parse_username_too_long(void **state)
 		"abcdefghijklmnopqrstuvwxyz1234567", "login"));
 }
 
+static void test_parse_rejects_xpath_user_injection(void **state)
+{
+	(void)state;
+	t_pusb_options opts;
+	pusb_conf_init(&opts);
+	assert_int_equal(0, pusb_conf_parse(FIXTURE_CONF, &opts,
+		"' or @id='user_mixed", "login"));
+}
+
+static void test_parse_rejects_xpath_service_injection(void **state)
+{
+	(void)state;
+	t_pusb_options opts;
+	pusb_conf_init(&opts);
+	assert_int_equal(0, pusb_conf_parse(FIXTURE_CONF, &opts,
+		"user_mixed", "' or @id='sudo"));
+}
+
+static void test_parse_rejects_xpath_device_id_injection(void **state)
+{
+	(void)state;
+	char tmpfile[] = "/tmp/pamusb_test_device_xpath_XXXXXX";
+	int fd = mkstemp(tmpfile);
+	assert_true(fd >= 0);
+	const char *xml =
+		"<?xml version=\"1.0\"?>"
+		"<configuration>"
+		"  <devices>"
+		"    <device id=\"victim\"><vendor>V</vendor><model>M</model>"
+		"      <serial>S001</serial><volume_uuid>UUID-A</volume_uuid></device>"
+		"  </devices>"
+		"  <users>"
+		"    <user id=\"testuser\"><device>' or @id='victim</device></user>"
+		"  </users>"
+		"  <services>"
+		"    <service id=\"login\"></service>"
+		"  </services>"
+		"</configuration>";
+	write(fd, xml, strlen(xml));
+	close(fd);
+
+	t_pusb_options opts;
+	pusb_conf_init(&opts);
+	assert_int_equal(0, pusb_conf_parse(tmpfile, &opts, "testuser", "login"));
+	unlink(tmpfile);
+}
+
 static void test_parse_user_not_in_conf(void **state)
 {
 	(void)state;
@@ -219,6 +266,9 @@ int main(void)
 		cmocka_unit_test(test_parse_nonexistent_file),
 		cmocka_unit_test(test_parse_invalid_xml),
 		cmocka_unit_test(test_parse_username_too_long),
+		cmocka_unit_test(test_parse_rejects_xpath_user_injection),
+		cmocka_unit_test(test_parse_rejects_xpath_service_injection),
+		cmocka_unit_test(test_parse_rejects_xpath_device_id_injection),
 		cmocka_unit_test(test_parse_user_not_in_conf),
 		cmocka_unit_test(test_superuser_attribute_case_sensitive),
 	};


### PR DESCRIPTION
Related to #55. This is a separate config-parser hardening path from the tmux PR. It looks at the XPath predicates built from PAM user/service names and configured device ids.

Summary:
- reject empty, single-quote, and control-character lookup ids before building single-quoted XPath predicates
- remove the 32-byte temporary user/service copies in option parsing, which could silently truncate lookup values
- add regressions for user, service, and device-id XPath injection attempts

Testing:
- `gcc -D_UTSNAME_NODENAME_LENGTH=65 -fsyntax-only -Wall -I src $(pkg-config --cflags libxml-2.0) src/conf.c`
- temporary standalone smoke harness against the real parser for the three injection paths, then removed before commit
- `git diff --check`
- `make test-c-conf` is blocked in my local macOS environment by missing Linux/pkg-config deps (`udisks2`, `libevdev`) and `_UTSNAME_NODENAME_LENGTH`; cmocka is also not available locally.

AI-assisted audit/fix, reviewed and narrowed before submission.