### PR TITLE
#305 Fix `pamusb-conf --reset-pads` only works on the primary/first device

### DIFF
--- a/tests/can-actually-be-used/mount-image.sh
+++ b/tests/can-actually-be-used/mount-image.sh
@@ -18,3 +18,11 @@ sudo mkfs.vfat "/dev/"$CREATED_DEVICE"1"
 # Create mountpoint and mount fake stick
 mkdir -p /tmp/fakestick
 sudo mount -t vfat "/dev/"$CREATED_DEVICE"1" /tmp/fakestick -o rw,umask=0000
+
+# Prepare alt image (second device) with its own partition + vfat filesystem
+echo "Info: preparing virtual_usb_alt.img for second device..."
+LOOP=$(sudo losetup --find --show virtual_usb_alt.img)
+echo 'type=83' | sudo sfdisk $LOOP
+sudo partprobe $LOOP
+sudo mkfs.vfat "${LOOP}p1"
+sudo losetup -d $LOOP

--- a/tests/can-actually-be-used/mount-image.sh
+++ b/tests/can-actually-be-used/mount-image.sh
@@ -2,25 +2,24 @@
 
 set -e
 
-# Load module with image
+# Format both images offline — sfdisk and mkfs.vfat work directly on raw files
+echo "Info: preparing virtual_usb.img..."
+echo 'type=83' | sfdisk virtual_usb.img
+mkfs.vfat --offset 2048 virtual_usb.img
+
+echo "Info: preparing virtual_usb_alt.img for second device..."
+echo 'type=83' | sfdisk virtual_usb_alt.img
+mkfs.vfat --offset 2048 virtual_usb_alt.img
+
+# Load module with primary image
 sudo modprobe g_mass_storage file=./virtual_usb.img stall=0 removable=y iSerialNumber=1234567890 iProduct=FirstStick
 echo "Info: sleeping 5s to ensure kernel picks up our new device..."
 sleep 5
 
-# Determine device id, create partition and format it
+# Determine device id and mount it
 CREATED_DEVICE=$(lsblk | grep disk | grep 16M | awk '{ print $1 }')
 echo "Info: fake device registered as /dev/$CREATED_DEVICE"
-echo "Info: creating partition..."
-echo 'type=83' | sudo sfdisk /dev/$CREATED_DEVICE
-echo "Info: formatting partition as vfat..."
-sudo mkfs.vfat "/dev/"$CREATED_DEVICE"1"
 
 # Create mountpoint and mount fake stick
 mkdir -p /tmp/fakestick
 sudo mount -t vfat "/dev/"$CREATED_DEVICE"1" /tmp/fakestick -o rw,umask=0000
-
-# Prepare alt image (second device) with its own partition + vfat filesystem
-# sfdisk and mkfs.vfat operate directly on the raw file — no loopback or sudo needed
-echo "Info: preparing virtual_usb_alt.img for second device..."
-echo 'type=83' | sfdisk virtual_usb_alt.img
-mkfs.vfat --offset 2048 virtual_usb_alt.img

--- a/tests/can-actually-be-used/mount-image.sh
+++ b/tests/can-actually-be-used/mount-image.sh
@@ -20,9 +20,7 @@ mkdir -p /tmp/fakestick
 sudo mount -t vfat "/dev/"$CREATED_DEVICE"1" /tmp/fakestick -o rw,umask=0000
 
 # Prepare alt image (second device) with its own partition + vfat filesystem
+# sfdisk and mkfs.vfat operate directly on the raw file — no loopback or sudo needed
 echo "Info: preparing virtual_usb_alt.img for second device..."
-LOOP=$(sudo losetup --find --show virtual_usb_alt.img)
-echo 'type=83' | sudo sfdisk $LOOP
-sudo partprobe $LOOP
-sudo mkfs.vfat "${LOOP}p1"
-sudo losetup -d $LOOP
+echo 'type=83' | sfdisk virtual_usb_alt.img
+mkfs.vfat --offset 2048 virtual_usb_alt.img

--- a/tests/can-actually-be-used/run-tests.sh
+++ b/tests/can-actually-be-used/run-tests.sh
@@ -12,6 +12,7 @@ rm -rf /home/`whoami`/.pamusb
 ./test-conf-adds-user.sh && \
 ./test-conf-doesnt-add-user-twice-but-adds-a-second-device.sh && \
 ./test-check-verify-created-config.sh && \
+./test-conf-reset-pads.sh && \
 ./test-check-superuser-filtering.sh && \
 rm -rf /tmp/fakestick/.pamusb && \
 ./test-agent-properly-triggers.sh

--- a/tests/can-actually-be-used/test-conf-doesnt-add-user-twice-but-adds-a-second-device.sh
+++ b/tests/can-actually-be-used/test-conf-doesnt-add-user-twice-but-adds-a-second-device.sh
@@ -9,7 +9,7 @@ sudo modprobe -r g_mass_storage || exit 1
 sleep 10
 
 # "plug" another virtual usb
-sudo modprobe g_mass_storage file=./virtual_usb.img stall=0 removable=y iSerialNumber=1234567891 iProduct=SecondStick || exit 1
+sudo modprobe g_mass_storage file=./virtual_usb_alt.img stall=0 removable=y iSerialNumber=1234567891 iProduct=SecondStick || exit 1
 sleep 10
 CREATED_DEVICE=$(lsblk | grep 16M | awk '{ print $1 }')
 sudo mount -t vfat "/dev/"$CREATED_DEVICE"1" /tmp/fakestick -o rw,umask=0000

--- a/tests/can-actually-be-used/test-conf-reset-pads.sh
+++ b/tests/can-actually-be-used/test-conf-reset-pads.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/bash
+
+echo -e "Test:\t\t\tpamusb-conf --reset-pads resets pads for all connected devices"
+
+# Pre-condition: pads for test2 must exist from the previous pamusb-check run
+[ -f "/home/$USERNAME/.pamusb/test2.pad" ] || { echo -e "Result:\t\t\tFAILED (pre-condition: system pad for test2 not found)"; exit 1; }
+[ -f "/tmp/fakestick/.pamusb/$USERNAME.$HOSTNAME.pad" ] || { echo -e "Result:\t\t\tFAILED (pre-condition: device pad not found)"; exit 1; }
+
+# Run --reset-pads and capture output
+echo -en "pamusb-conf --reset-pads output:\t"
+RESET_OUTPUT=$(sudo pamusb-conf --reset-pads=$USERNAME 2>&1)
+echo "$RESET_OUTPUT" | head -1
+
+# test2 pads must be gone
+[ ! -f "/home/$USERNAME/.pamusb/test2.pad" ] || { echo -e "Result:\t\t\tFAILED (system pad for test2 still exists)"; exit 1; }
+[ ! -f "/tmp/fakestick/.pamusb/$USERNAME.$HOSTNAME.pad" ] || { echo -e "Result:\t\t\tFAILED (device pad still exists)"; exit 1; }
+
+# test device (not connected) must have been reported as skipped
+echo "$RESET_OUTPUT" | grep -q "test.*not connected" || { echo -e "Result:\t\t\tFAILED (expected skip warning for disconnected device 'test')"; exit 1; }
+
+# pamusb-check must still succeed and regenerate pads
+pamusb-check --debug $USERNAME > /dev/null 2>&1 || { echo -e "Result:\t\t\tFAILED (pamusb-check failed after pad reset)"; exit 1; }
+[ -f "/home/$USERNAME/.pamusb/test2.pad" ] || { echo -e "Result:\t\t\tFAILED (system pad for test2 not regenerated)"; exit 1; }
+[ -f "/tmp/fakestick/.pamusb/$USERNAME.$HOSTNAME.pad" ] || { echo -e "Result:\t\t\tFAILED (device pad not regenerated)"; exit 1; }
+
+echo -e "Result:\t\t\tPASSED!"

--- a/tests/can-actually-be-used/test-conf-reset-pads.sh
+++ b/tests/can-actually-be-used/test-conf-reset-pads.sh
@@ -3,24 +3,24 @@
 echo -e "Test:\t\t\tpamusb-conf --reset-pads resets pads for all connected devices"
 
 # Pre-condition: pads for test2 must exist from the previous pamusb-check run
-[ -f "/home/$USERNAME/.pamusb/test2.pad" ] || { echo -e "Result:\t\t\tFAILED (pre-condition: system pad for test2 not found)"; exit 1; }
-[ -f "/tmp/fakestick/.pamusb/$USERNAME.$HOSTNAME.pad" ] || { echo -e "Result:\t\t\tFAILED (pre-condition: device pad not found)"; exit 1; }
+[ -f "$HOME/.pamusb/test2.pad" ] || { echo -e "Result:\t\t\tFAILED (pre-condition: system pad for test2 not found)"; exit 1; }
+[ -f "/tmp/fakestick/.pamusb/$USER.$HOSTNAME.pad" ] || { echo -e "Result:\t\t\tFAILED (pre-condition: device pad not found)"; exit 1; }
 
 # Run --reset-pads and capture output
 echo -en "pamusb-conf --reset-pads output:\t"
-RESET_OUTPUT=$(sudo pamusb-conf --reset-pads=$USERNAME 2>&1)
+RESET_OUTPUT=$(sudo pamusb-conf --reset-pads=$USER 2>&1)
 echo "$RESET_OUTPUT" | head -1
 
 # test2 pads must be gone
-[ ! -f "/home/$USERNAME/.pamusb/test2.pad" ] || { echo -e "Result:\t\t\tFAILED (system pad for test2 still exists)"; exit 1; }
-[ ! -f "/tmp/fakestick/.pamusb/$USERNAME.$HOSTNAME.pad" ] || { echo -e "Result:\t\t\tFAILED (device pad still exists)"; exit 1; }
+[ ! -f "$HOME/.pamusb/test2.pad" ] || { echo -e "Result:\t\t\tFAILED (system pad for test2 still exists)"; exit 1; }
+[ ! -f "/tmp/fakestick/.pamusb/$USER.$HOSTNAME.pad" ] || { echo -e "Result:\t\t\tFAILED (device pad still exists)"; exit 1; }
 
 # test device (not connected) must have been reported as skipped
 echo "$RESET_OUTPUT" | grep -q "test.*not connected" || { echo -e "Result:\t\t\tFAILED (expected skip warning for disconnected device 'test')"; exit 1; }
 
 # pamusb-check must still succeed and regenerate pads
-pamusb-check --debug $USERNAME > /dev/null 2>&1 || { echo -e "Result:\t\t\tFAILED (pamusb-check failed after pad reset)"; exit 1; }
-[ -f "/home/$USERNAME/.pamusb/test2.pad" ] || { echo -e "Result:\t\t\tFAILED (system pad for test2 not regenerated)"; exit 1; }
-[ -f "/tmp/fakestick/.pamusb/$USERNAME.$HOSTNAME.pad" ] || { echo -e "Result:\t\t\tFAILED (device pad not regenerated)"; exit 1; }
+pamusb-check --debug $USER > /dev/null 2>&1 || { echo -e "Result:\t\t\tFAILED (pamusb-check failed after pad reset)"; exit 1; }
+[ -f "$HOME/.pamusb/test2.pad" ] || { echo -e "Result:\t\t\tFAILED (system pad for test2 not regenerated)"; exit 1; }
+[ -f "/tmp/fakestick/.pamusb/$USER.$HOSTNAME.pad" ] || { echo -e "Result:\t\t\tFAILED (device pad not regenerated)"; exit 1; }
 
 echo -e "Result:\t\t\tPASSED!"

--- a/tests/can-actually-be-used/umount-image.sh
+++ b/tests/can-actually-be-used/umount-image.sh
@@ -4,5 +4,6 @@ sudo umount /tmp/fakestick
 sudo modprobe -r g_mass_storage
 
 rm virtual_usb.img
+rm -f virtual_usb_alt.img
 rm -rf /tmp/fakestick
 rm -rf /home/`whoami`/.pamusb

--- a/tests/unit/python/test_pamusb_conf.py
+++ b/tests/unit/python/test_pamusb_conf.py
@@ -194,6 +194,84 @@ def test_add_user_no_duplicate_on_second_call(tmp_conf):
 # ── C-2 regression: UUID validation ──────────────────────────────────────────
 
 import re as _re
+import subprocess
+
+
+# ── resetPads — multi-device regressions (#305) ──────────────────────────────
+
+_TWO_DEVICE_XML = (
+    '<?xml version="1.0"?>'
+    "<configuration>"
+    "  <devices>"
+    '    <device id="dev1"><volume_uuid>AAAA-1111</volume_uuid></device>'
+    '    <device id="dev2"><volume_uuid>BBBB-2222</volume_uuid></device>'
+    "  </devices>"
+    "  <users>"
+    '    <user id="testuser">'
+    "      <device>dev1</device>"
+    "      <device>dev2</device>"
+    "    </user>"
+    "  </users>"
+    "</configuration>"
+)
+
+
+def test_reset_pads_processes_all_devices_when_connected(tmp_path):
+    """#305 regression: resetPads removes pads for every device when all are connected."""
+    removed = []
+
+    with patch.object(_mod, "minidom") as mock_mini, \
+         patch.object(_mod, "os") as mock_os, \
+         patch.object(_mod, "subprocess") as mock_sub, \
+         patch.object(_mod, "socket") as mock_sock:
+
+        mock_mini.parse.return_value = minidom.parseString(_TWO_DEVICE_XML)
+        mock_os.remove.side_effect = lambda p: removed.append(p)
+        mock_sub.check_output.side_effect = [b"/mnt/dev1\n", b"/mnt/dev2\n"]
+        mock_sub.CalledProcessError = subprocess.CalledProcessError
+        mock_sub.DEVNULL = subprocess.DEVNULL
+        mock_sock.gethostname.return_value = "testhost"
+
+        _mod.options = {"configFile": "/fake/conf", "resetPads": "testuser"}
+
+        with pytest.raises(SystemExit):
+            _mod.resetPads()
+
+    assert "/home/testuser/.pamusb/dev1.pad" in removed
+    assert "/home/testuser/.pamusb/dev2.pad" in removed
+    assert "/mnt/dev1/.pamusb/testuser.testhost.pad" in removed
+    assert "/mnt/dev2/.pamusb/testuser.testhost.pad" in removed
+    assert len(removed) == 4
+
+
+def test_reset_pads_skips_disconnected_device_atomically(tmp_path):
+    """#305 + connected-device constraint: if dev2 is not mounted, neither of its pads is touched."""
+    removed = []
+
+    with patch.object(_mod, "minidom") as mock_mini, \
+         patch.object(_mod, "os") as mock_os, \
+         patch.object(_mod, "subprocess") as mock_sub, \
+         patch.object(_mod, "socket") as mock_sock:
+
+        mock_mini.parse.return_value = minidom.parseString(_TWO_DEVICE_XML)
+        mock_os.remove.side_effect = lambda p: removed.append(p)
+        mock_sub.check_output.side_effect = [
+            b"/mnt/dev1\n",
+            subprocess.CalledProcessError(1, "findmnt"),
+        ]
+        mock_sub.CalledProcessError = subprocess.CalledProcessError
+        mock_sub.DEVNULL = subprocess.DEVNULL
+        mock_sock.gethostname.return_value = "testhost"
+
+        _mod.options = {"configFile": "/fake/conf", "resetPads": "testuser"}
+
+        with pytest.raises(SystemExit):
+            _mod.resetPads()
+
+    assert "/home/testuser/.pamusb/dev1.pad" in removed
+    assert "/mnt/dev1/.pamusb/testuser.testhost.pad" in removed
+    assert len(removed) == 2
+    assert "/home/testuser/.pamusb/dev2.pad" not in removed
 
 
 def _uuid_is_valid(uuid: str) -> bool:

--- a/tools/pamusb-conf
+++ b/tools/pamusb-conf
@@ -332,6 +332,7 @@ def addDevice(options):
 
 def resetPads():
 	padFiles = []
+	skippedDevices = []
 
 	try:
 		doc = minidom.parse(options['configFile'])
@@ -351,45 +352,58 @@ def resetPads():
 	if len(alreadyConfiguredUsers) > 0:
 		for user in alreadyConfiguredUsers:
 			if user.getAttribute('id') == options['resetPads']:
-				# Device specific pad for user
-				userDevice = user.getElementsByTagName('device')[0].firstChild.nodeValue
-				if '/' in userDevice or '..' in userDevice:
-					print('Invalid device ID in config (path traversal): %s' % userDevice)
-					sys.exit(1)
-				padFiles.append('/home/%s/.pamusb/%s.pad' % (options['resetPads'], userDevice))
+				for userDeviceNode in user.getElementsByTagName('device'):
+					userDevice = userDeviceNode.firstChild.nodeValue
+					if '/' in userDevice or '..' in userDevice:
+						print('Invalid device ID in config (path traversal): %s' % userDevice)
+						sys.exit(1)
 
-				# User specific pad for device
-				for details in devicesObj:
-					if details.getAttribute('id') == userDevice:
-						deviceUUID = details.getElementsByTagName('volume_uuid')[0].firstChild.nodeValue
-						if not re.match(r'^[0-9a-fA-F\-]+$', deviceUUID):
-							print('Invalid device UUID in config: %s' % deviceUUID)
-							sys.exit(1)
-						try:
-							deviceMountPoint = subprocess.check_output(
-								['findmnt', '-n', '-o', 'TARGET', '--source', '/dev/disk/by-uuid/' + deviceUUID],
-								stderr=subprocess.DEVNULL
-							)
-							padFiles.append('%s/.pamusb/%s.%s.pad' % (deviceMountPoint.decode().strip(), options['resetPads'], socket.gethostname()))
-						except subprocess.CalledProcessError as err:
-							print('Could not get device mountpoint: ', err)
+					systemPad = '/home/%s/.pamusb/%s.pad' % (options['resetPads'], userDevice)
+					devicePad = None
 
-	if len(padFiles) == 0:
+					for details in devicesObj:
+						if details.getAttribute('id') == userDevice:
+							deviceUUID = details.getElementsByTagName('volume_uuid')[0].firstChild.nodeValue
+							if not re.match(r'^[0-9a-fA-F\-]+$', deviceUUID):
+								print('Invalid device UUID in config: %s' % deviceUUID)
+								sys.exit(1)
+							try:
+								deviceMountPoint = subprocess.check_output(
+									['findmnt', '-n', '-o', 'TARGET', '--source', '/dev/disk/by-uuid/' + deviceUUID],
+									stderr=subprocess.DEVNULL
+								)
+								devicePad = '%s/.pamusb/%s.%s.pad' % (
+									deviceMountPoint.decode().strip(),
+									options['resetPads'],
+									socket.gethostname()
+								)
+							except subprocess.CalledProcessError:
+								pass
+
+					if devicePad is None:
+						print('Device %s is not connected, skipping (connect it and re-run to reset its pads).' % userDevice)
+						skippedDevices.append(userDevice)
+					else:
+						padFiles.append(systemPad)
+						padFiles.append(devicePad)
+
+	if len(padFiles) == 0 and not skippedDevices:
 		print('Could not find pad files to reset, wtf?!')
 		sys.exit(1)
 
-	print('Pad files to remove: ', padFiles)
-	print('Removing device specific pad for user %s...' % options['resetPads'])
-	try:
-		os.remove(padFiles[0])
-	except FileNotFoundError as fnf:
-		print('    Notice: pad file not found.')
+	if padFiles:
+		print('Pad files to remove: ', padFiles)
+		for padFile in padFiles:
+			print('Removing pad file: %s...' % padFile)
+			try:
+				os.remove(padFile)
+			except FileNotFoundError:
+				print('    Notice: pad file not found.')
 
-	print('Removing user and hostname specific pad on device with UUID %s...' % deviceUUID)
-	try:
-		os.remove(padFiles[1])
-	except FileNotFoundError as fnf:
-		print('    Notice: pad file not found.')
+	if skippedDevices:
+		print('')
+		print('Warning: the following devices were not connected and their pads were NOT reset: %s' % ', '.join(skippedDevices))
+		print('Connect them and re-run --reset-pads to complete the reset.')
 
 	print('')
 	print('All pad files for the given user were deleted, on next successful authentication they will be regenerated (you can force this by running pamusb-check).')


### PR DESCRIPTION
Closes #305

## Root cause

`resetPads()` in `tools/pamusb-conf` used `getElementsByTagName('device')[0]` — a hardcoded index — so only the first configured device's pads were removed when a user had multiple devices. The removal section also indexed `padFiles[0]` and `padFiles[1]` directly, which would have crashed for any deviation from exactly two entries.

## Changes

### `tools/pamusb-conf`

- `resetPads()` now iterates **all** `<device>` elements for the user instead of taking `[0]`.
- For each device, `findmnt` resolves the mount point via UUID. If the device is **not connected**, both its pads are skipped atomically — deleting only the system pad would leave things in a broken half-state where `pusb_pad_compare()` (F3 protection) denies auth because the system pad is absent but the device pad still exists on the USB. Skipped devices are collected and reported in a warning with instructions to reconnect and re-run.
- Removal is now a loop over `padFiles` instead of hardcoded positional access.

### `tests/unit/python/test_pamusb_conf.py`

Two new regression tests:
- **All devices connected:** asserts all four pad files (system + device pad × 2 devices) are removed.
- **One device disconnected:** asserts only the connected device's two pads are removed and the disconnected device's system pad is left untouched.

### `tests/can-actually-be-used/test-conf-reset-pads.sh` (new)

Integration test inserted in `run-tests.sh` after `test-check-verify-created-config.sh`. At that point both `test` and `test2` are configured, but only `test2` is mounted. Verifies:
1. Pre-condition: pads for `test2` exist from the prior `pamusb-check` run.
2. After `--reset-pads`, `test2`'s system and device pads are gone.
3. The disconnected device `test` is reported as skipped in the output.
4. `pamusb-check` still succeeds after the reset and regenerates both pad files.

### `tests/can-actually-be-used/` — test infrastructure improvements

To make `test` and `test2` genuinely distinct devices (different UUIDs), the second virtual USB now uses `virtual_usb_alt.img` instead of reusing `virtual_usb.img`. Both images are now partitioned and formatted offline as raw files before `g_mass_storage` loads them, eliminating the need for `sudo sfdisk` / `sudo mkfs.vfat` on a block device and removing any dependency on `losetup`. Only `modprobe` and `mount` still require elevated privileges during setup.