### PR TITLE
#304 Add integration test for pamusb-pinentry --install / --uninstall

### DIFF
--- a/.github/workflows/build-and-test-on-own-server.yml
+++ b/.github/workflows/build-and-test-on-own-server.yml
@@ -37,7 +37,7 @@ jobs:
         TEST_RUNNER_PASS_NEW: ${{ secrets.TEST_RUNNER_PASS_2025 }}
         TEST_RUNNER_PORT_NEW: ${{ secrets.TEST_RUNNER_PORT_NEW }}
       # NOTE: deps are installed directly on the remote host via SSH; keep in sync with .github/actions/install-build-deps/action.yml
-      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "sudo apt --yes install fdisk libudisks2-dev libxml2-dev python-is-python3 libpam0g-dev devscripts debhelper dkms pkg-config gir1.2-glib-2.0 libglib2.0-dev libevdev-dev"
+      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "sudo apt --yes install fdisk libudisks2-dev libxml2-dev python-is-python3 python3-dotenv libpam0g-dev devscripts debhelper dkms pkg-config gir1.2-glib-2.0 libglib2.0-dev libevdev-dev"
     - name: git clone
       env:
         TEST_RUNNER_HOST_NEW: ${{ secrets.TEST_RUNNER_HOST_NEW }}

--- a/tests/can-actually-be-used/run-tests.sh
+++ b/tests/can-actually-be-used/run-tests.sh
@@ -7,6 +7,7 @@ rm -rf /home/`whoami`/.pamusb
 
 # Run tests
 ./test-keyring-unlock-gnome-installer.sh && \
+./test-pinentry-installer.sh && \
 ./test-conf-detects-device.sh && \
 ./test-conf-adds-device.sh && \
 ./test-conf-adds-user.sh && \

--- a/tests/can-actually-be-used/test-pinentry-installer.sh
+++ b/tests/can-actually-be-used/test-pinentry-installer.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/bash
+set -e
+echo -e "Test:\t\t\tpamusb-pinentry --install / --uninstall"
+
+FAKE_HOME=$(mktemp -d)
+MOCK_BIN=$(mktemp -d)
+MOCK_LOG=$(mktemp)
+trap "rm -rf $FAKE_HOME $MOCK_BIN $MOCK_LOG" EXIT
+
+TOOL=$(which pamusb-pinentry)
+
+# Mock update-alternatives: log all calls, always succeed.
+# printf expands $MOCK_LOG now; $@ stays literal inside the generated script.
+printf '#!/usr/bin/bash\necho "$@" >> %s\nexit 0\n' "$MOCK_LOG" > "$MOCK_BIN/update-alternatives"
+chmod +x "$MOCK_BIN/update-alternatives"
+
+# --install
+HOME=$FAKE_HOME PATH="$MOCK_BIN:$PATH" $TOOL --install
+
+# verify envfile created with correct path, mode 0600, and default content
+[ -f "$FAKE_HOME/.pamusb/.pinentry.env" ]
+PERMS=$(stat -c "%a" "$FAKE_HOME/.pamusb/.pinentry.env")
+[ "$PERMS" = "600" ]
+grep -q 'PINENTRY_PASSWORD=changeme' "$FAKE_HOME/.pamusb/.pinentry.env"
+
+# verify update-alternatives --install and --set were called
+grep -q -- "--install /usr/bin/pinentry pinentry /usr/bin/pamusb-pinentry 100" "$MOCK_LOG"
+grep -q -- "--set pinentry /usr/bin/pamusb-pinentry" "$MOCK_LOG"
+
+# idempotency: --install again must not overwrite existing envfile
+HOME=$FAKE_HOME PATH="$MOCK_BIN:$PATH" $TOOL --install
+
+# --uninstall
+> "$MOCK_LOG"
+HOME=$FAKE_HOME PATH="$MOCK_BIN:$PATH" $TOOL --uninstall
+
+# verify envfile removed
+[ ! -f "$FAKE_HOME/.pamusb/.pinentry.env" ]
+
+# verify update-alternatives --remove was called
+grep -q -- "--remove pinentry /usr/bin/pamusb-pinentry" "$MOCK_LOG"
+
+echo -e "Result:\t\t\tPASSED!"


### PR DESCRIPTION
Exercises the real binary end-to-end: argument parsing, HOME env var handling, real filesystem writes, and update-alternatives call verification via a mock. Wired into run-tests.sh after the keyring installer test.

Closes #304 