### PR TITLE
Harden tmux local login checks

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -70,11 +70,6 @@ static int pusb_utmpx_field_starts_with(const char *field, size_t field_len, con
 	return prefix_len <= field_len && memcmp(field, prefix, prefix_len) == 0;
 }
 
-static int pusb_should_check_tmux(pid_t tmux_pid)
-{
-	return tmux_pid != 0;
-}
-
 int pusb_is_tty_local(char *tty)
 {
 	struct utmpx utsearch;
@@ -375,7 +370,7 @@ int pusb_local_login(t_pusb_options *opts, const char *user, const char *service
 	const char *session_tty;
 	const char *display_env = getenv("DISPLAY");
 
-	if (local_request == 0 && pusb_should_check_tmux(tmux_pid))
+	if (local_request == 0 && tmux_pid != 0)
 	{
 		log_debug("	Checking for remote clients attached to tmux before getting client tty...\n");
 		if (pusb_tmux_has_remote_clients(user) != 0)

--- a/src/local.c
+++ b/src/local.c
@@ -70,6 +70,11 @@ static int pusb_utmpx_field_starts_with(const char *field, size_t field_len, con
 	return prefix_len <= field_len && memcmp(field, prefix, prefix_len) == 0;
 }
 
+static int pusb_should_check_tmux(pid_t tmux_pid)
+{
+	return tmux_pid != 0;
+}
+
 int pusb_is_tty_local(char *tty)
 {
 	struct utmpx utsearch;
@@ -119,19 +124,19 @@ char *pusb_get_tty_from_display_server(const char *display)
 		return NULL;
 	}
 
-	char *cmdline_path = (char *)xmalloc(32);
+	char *cmdline_path = (char *)xmalloc(PATH_MAX);
 	char *cmdline = (char *)xmalloc(4096);
-	char *fd_path = (char *)xmalloc(32);
-	char *link_path = (char *)xmalloc(32);
-	char *fd_target = (char *)xmalloc(32);
+	char *fd_path = (char *)xmalloc(PATH_MAX);
+	char *link_path = (char *)xmalloc(PATH_MAX);
+	char *fd_target = (char *)xmalloc(PATH_MAX);
 
 	struct dirent *dent_proc;
 	while ((dent_proc = readdir(d_proc)) != NULL)
 	{
 		if (dent_proc->d_type == DT_DIR && atoi(dent_proc->d_name) != 0 && strcmp(dent_proc->d_name, ".") != 0 && strcmp(dent_proc->d_name, "..") != 0)
 		{
-			memset(cmdline_path, 0, 32);
-			snprintf(cmdline_path, 32, "/proc/%s/cmdline", dent_proc->d_name);
+			memset(cmdline_path, 0, PATH_MAX);
+			snprintf(cmdline_path, PATH_MAX, "/proc/%s/cmdline", dent_proc->d_name);
 
 			memset(cmdline, 0, 4096);
 			int cmdline_file = open(cmdline_path, O_RDONLY | O_CLOEXEC);
@@ -150,8 +155,8 @@ char *pusb_get_tty_from_display_server(const char *display)
 				|| strstr(cmdline, "gnome-session-binary") != NULL
 				|| strstr(cmdline, "gdm-wayland-session") != NULL) //@todo: find & add other wayland hosts
 			{
-				memset(fd_path, 0, 32);
-				snprintf(fd_path, 32, "/proc/%s/fd", dent_proc->d_name);
+				memset(fd_path, 0, PATH_MAX);
+				snprintf(fd_path, PATH_MAX, "/proc/%s/fd", dent_proc->d_name);
 
 				DIR *d_fd = opendir(fd_path);
 				if (d_fd == NULL) {
@@ -172,11 +177,11 @@ char *pusb_get_tty_from_display_server(const char *display)
 				{
 					if (dent_fd->d_type == DT_LNK && strcmp(dent_fd->d_name, ".") != 0 && strcmp(dent_fd->d_name, "..") != 0)
 					{
-						memset(link_path, 0, 32);
-						memset(fd_target, 0, 32);
+						memset(link_path, 0, PATH_MAX);
+						memset(fd_target, 0, PATH_MAX);
 
-						snprintf(link_path, 32, "/proc/%s/fd/%s", dent_proc->d_name, dent_fd->d_name);
-						ssize_t rlen = readlink(link_path, fd_target, 31);
+						snprintf(link_path, PATH_MAX, "/proc/%s/fd/%s", dent_proc->d_name, dent_fd->d_name);
+						ssize_t rlen = readlink(link_path, fd_target, PATH_MAX - 1);
 						if (rlen != -1)
 						{
 							fd_target[rlen] = '\0';
@@ -370,7 +375,7 @@ int pusb_local_login(t_pusb_options *opts, const char *user, const char *service
 	const char *session_tty;
 	const char *display_env = getenv("DISPLAY");
 
-	if (local_request == 0 && strstr(name, "tmux") != NULL && tmux_pid != 0) 
+	if (local_request == 0 && pusb_should_check_tmux(tmux_pid))
 	{
 		log_debug("	Checking for remote clients attached to tmux before getting client tty...\n");
 		if (pusb_tmux_has_remote_clients(user) != 0)

--- a/tests/unit/c/local_test.c
+++ b/tests/unit/c/local_test.c
@@ -102,20 +102,6 @@ static void test_utmpx_field_starts_with_rejects_long_prefix(void **state)
 	assert_int_equal(0, pusb_utmpx_field_starts_with(field, sizeof(field), "pts/"));
 }
 
-static void test_should_check_tmux_rejects_missing_pid(void **state)
-{
-	(void)state;
-
-	assert_int_equal(0, pusb_should_check_tmux(0));
-}
-
-static void test_should_check_tmux_accepts_recorded_pid(void **state)
-{
-	(void)state;
-
-	assert_int_equal(1, pusb_should_check_tmux(1234));
-}
-
 int main(void)
 {
 	const struct CMUnitTest tests[] = {
@@ -129,8 +115,6 @@ int main(void)
 		cmocka_unit_test(test_utmpx_field_starts_with_pts_slave),
 		cmocka_unit_test(test_utmpx_field_starts_with_full_width_field),
 		cmocka_unit_test(test_utmpx_field_starts_with_rejects_long_prefix),
-		cmocka_unit_test(test_should_check_tmux_rejects_missing_pid),
-		cmocka_unit_test(test_should_check_tmux_accepts_recorded_pid),
 	};
 	return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/tests/unit/c/local_test.c
+++ b/tests/unit/c/local_test.c
@@ -102,6 +102,20 @@ static void test_utmpx_field_starts_with_rejects_long_prefix(void **state)
 	assert_int_equal(0, pusb_utmpx_field_starts_with(field, sizeof(field), "pts/"));
 }
 
+static void test_should_check_tmux_rejects_missing_pid(void **state)
+{
+	(void)state;
+
+	assert_int_equal(0, pusb_should_check_tmux(0));
+}
+
+static void test_should_check_tmux_accepts_recorded_pid(void **state)
+{
+	(void)state;
+
+	assert_int_equal(1, pusb_should_check_tmux(1234));
+}
+
 int main(void)
 {
 	const struct CMUnitTest tests[] = {
@@ -115,6 +129,8 @@ int main(void)
 		cmocka_unit_test(test_utmpx_field_starts_with_pts_slave),
 		cmocka_unit_test(test_utmpx_field_starts_with_full_width_field),
 		cmocka_unit_test(test_utmpx_field_starts_with_rejects_long_prefix),
+		cmocka_unit_test(test_should_check_tmux_rejects_missing_pid),
+		cmocka_unit_test(test_should_check_tmux_accepts_recorded_pid),
 	};
 	return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
## Summary
- fixes the tmux remote-client check so it runs whenever a tmux ancestor PID was recorded, instead of depending on the final process name left after walking the parent chain
- expands the `/proc/...` path buffers in the display-server TTY fallback from 32 bytes to `PATH_MAX`, removing truncation warnings in that path
- adds unit coverage for the tmux-check gate in `local_test`

Related to the security audit bounty in #55.

## Verification
- `make -j2`
- `make test-c` (127 C unit tests passing)
- `git diff --check`
