### PR TITLE
Harden XPath string copying

### DIFF
--- a/src/xpath.c
+++ b/src/xpath.c
@@ -53,10 +53,11 @@ static int pusb_xpath_strip_string(char *dest, const char *src, size_t size)
 	int first_char = -1;
 	int last_char = -1;
 	int i;
+	size_t len;
 
 	for (i = 0; src[i]; ++i)
 	{
-		if (isspace(src[i]))
+		if (isspace((unsigned char)src[i]))
 		{
 			continue;
 		}
@@ -74,14 +75,16 @@ static int pusb_xpath_strip_string(char *dest, const char *src, size_t size)
 		return 0;
 	}
 
-	if ((last_char - first_char) > (size - 1))
+	len = (size_t)(last_char - first_char + 1);
+	if (size == 0 || len >= size)
 	{
 		log_error("Device name is too long: %s", src);
 		return 0;
 	}
 
 	memset(dest, 0x0, size);
-	strncpy(dest, &(src[first_char]), last_char - first_char + 1);
+	memcpy(dest, &(src[first_char]), len);
+	dest[len] = '\0';
 	return 1;
 }
 

--- a/tests/unit/c/xpath_test.c
+++ b/tests/unit/c/xpath_test.c
@@ -165,6 +165,25 @@ static void test_string_too_long(void **state)
 	xmlFreeDoc(doc);
 }
 
+static void test_string_exact_buffer_size_rejected(void **state)
+{
+	(void)state;
+	xmlDocPtr doc = make_doc("<r><v>abcd</v></r>");
+	char buf[4] = {0};
+	/* size=4 needs one byte for NUL, so 4 content bytes must fail. */
+	assert_int_equal(0, pusb_xpath_get_string(doc, "//r/v", buf, sizeof(buf)));
+	xmlFreeDoc(doc);
+}
+
+static void test_string_zero_size_rejected(void **state)
+{
+	(void)state;
+	xmlDocPtr doc = make_doc("<r><v>a</v></r>");
+	char buf[1] = {0};
+	assert_int_equal(0, pusb_xpath_get_string(doc, "//r/v", buf, 0));
+	xmlFreeDoc(doc);
+}
+
 /* ── pusb_xpath_get_string_list ── */
 
 static void test_string_list_multiple(void **state)
@@ -216,6 +235,8 @@ int main(void)
 		cmocka_unit_test(test_string_value),
 		cmocka_unit_test(test_string_whitespace_stripped),
 		cmocka_unit_test(test_string_too_long),
+		cmocka_unit_test(test_string_exact_buffer_size_rejected),
+		cmocka_unit_test(test_string_zero_size_rejected),
 		cmocka_unit_test(test_string_list_multiple),
 		cmocka_unit_test(test_string_list_single),
 	};


### PR DESCRIPTION
## Summary
- reject XPath string values that exactly fill the destination buffer so there is always room for the NUL terminator
- handle zero-size destinations safely before copying
- cast `isspace` input to `unsigned char`
- use `memcpy` plus an explicit terminator after the length check
- add unit coverage for exact-size and zero-size destination buffers

Related to the security audit bounty in #55.

## Verification
- `make -j2`
- `make test-c-xpath`
- `make test-c` (127 C unit tests passing)
- `git diff --check`

Note: `make test-c` still emits the existing `/proc/...` path truncation warnings from `src/local.c`; that is unrelated to this XPath change and is addressed separately in #318.