### PR TITLE
Parse proc stat comm safely

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -67,12 +67,14 @@ void pusb_get_process_parent_id(const pid_t pid, pid_t *ppid)
 		if (fgets(buffer, sizeof(buffer), fp) != NULL)
 		{
 			// See: https://man7.org/linux/man-pages/man5/proc.5.html section /proc/[pid]/stat
-			strtok(buffer, " "); // (1) pid  %d
-			strtok(NULL, " "); // (2) comm  %s
-			strtok(NULL, " "); // (3) state  %c
-			char *s_ppid = strtok(NULL, " "); // (4) ppid  %d
-			if (s_ppid != NULL)
-				*ppid = atoi(s_ppid);
+			char *comm_end = strrchr(buffer, ')');
+			char state;
+			long parsed_ppid;
+			if (comm_end != NULL &&
+				sscanf(comm_end + 1, " %c %ld", &state, &parsed_ppid) == 2)
+			{
+				*ppid = (pid_t)parsed_ppid;
+			}
 		}
 		fclose(fp);
 	}

--- a/tests/unit/c/process_test.c
+++ b/tests/unit/c/process_test.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <sys/prctl.h>
 #include <cmocka.h>
 #include "../../../src/process.h"
 #include "../../../src/conf.h"
@@ -50,6 +51,22 @@ static void test_ppid_self(void **state)
 	pid_t ppid = 0;
 	pusb_get_process_parent_id(getpid(), &ppid);
 	assert_true(ppid > 0);
+}
+
+static void test_ppid_self_with_space_in_comm(void **state)
+{
+	(void)state;
+	char original_name[16] = {0};
+	pid_t ppid = 0;
+	pid_t expected_ppid = getppid();
+
+	assert_int_equal(0, prctl(PR_GET_NAME, original_name, 0, 0, 0));
+	assert_int_equal(0, prctl(PR_SET_NAME, "pa musb", 0, 0, 0));
+
+	pusb_get_process_parent_id(getpid(), &ppid);
+
+	assert_int_equal(0, prctl(PR_SET_NAME, original_name, 0, 0, 0));
+	assert_int_equal((int)expected_ppid, (int)ppid);
 }
 
 static void test_ppid_init(void **state)
@@ -108,6 +125,7 @@ int main(void)
 		cmocka_unit_test(test_process_name_pid1),
 		cmocka_unit_test(test_process_name_invalid_pid),
 		cmocka_unit_test(test_ppid_self),
+		cmocka_unit_test(test_ppid_self_with_space_in_comm),
 		cmocka_unit_test(test_ppid_init),
 		cmocka_unit_test(test_ppid_invalid_pid),
 		cmocka_unit_test(test_envvar_path_found),


### PR DESCRIPTION
## Summary
- parse `/proc/<pid>/stat` by locating the closing `)` of the `comm` field instead of tokenizing by spaces
- preserve correct parent PID parsing when a process name contains spaces
- add a regression test that temporarily sets the test process name to `pa musb`

Related to the security audit bounty in #55.

## Verification
- `make -j2`
- `make test-c-process`
- `make test-c` (126 C unit tests passing)
- `git diff --check`

Note: `make test-c` still emits the existing `/proc/...` path truncation warnings from `src/local.c`; that is unrelated to this process parsing change and is addressed separately in #318.
