### PR TITLE
Use absolute pamusb-check path

### DIFF
--- a/tests/unit/python/test_pamusb_pinentry.py
+++ b/tests/unit/python/test_pamusb_pinentry.py
@@ -6,6 +6,7 @@ Security regression coverage:
   M-3: PINENTRY_FALLBACK_APP validation — nonexistent path rejected
   M-3: PINENTRY_FALLBACK_APP validation — non-executable file rejected
   M-3: valid executable fallback is invoked
+  M-4: pamusb-check is invoked by absolute path, not PATH lookup
   Happy path: authenticated + password configured → sends "D <password>" response
 
 _user_home() coverage:
@@ -125,6 +126,20 @@ def test_fallback_valid_executable_invoked(tmp_path, monkeypatch):
     script.chmod(0o755)
     code = _run_pinentry_fallback(tmp_path, str(script), monkeypatch)
     assert code is None
+
+
+def test_pamusb_check_uses_absolute_path():
+    """Authentication check must not be resolved through attacker-controlled PATH."""
+    mod = _load_pinentry()
+
+    with patch("subprocess.run", return_value=subprocess.CompletedProcess(
+            [], returncode=0, stdout=b"", stderr=b"")) as run_mock:
+        mod._run_pamusb_check("alice")
+
+    run_mock.assert_called_once_with(
+        ["/usr/bin/pamusb-check", "alice"],
+        capture_output=True
+    )
 
 
 # ── Happy path: pinentry protocol ─────────────────────────────────────────────

--- a/tools/pamusb-pinentry
+++ b/tools/pamusb-pinentry
@@ -37,6 +37,7 @@ ENVFILE_PATH = os.path.join(_user_home(), ".pamusb", ".pinentry.env")
 PINENTRY_LINK = "/usr/bin/pinentry"
 PINENTRY_ALT_NAME = "pinentry"
 PAMUSB_PINENTRY_PATH = "/usr/bin/pamusb-pinentry"
+PAMUSB_CHECK_PATH = "/usr/bin/pamusb-check"
 PINENTRY_ALT_PRIORITY = 100
 
 ENVFILE_TEMPLATE = (
@@ -107,6 +108,10 @@ def uninstall():
     print("pamusb-pinentry alternative removed.")
 
 
+def _run_pamusb_check(user):
+    return subprocess.run([PAMUSB_CHECK_PATH, user], capture_output=True)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="pam_usb pinentry tool"
@@ -135,7 +140,7 @@ if __name__ == "__main__":
     pinentryPassword = os.getenv('PINENTRY_PASSWORD')
     fallbackPinentryApp = os.getenv('PINENTRY_FALLBACK_APP')
 
-    isAuthenticated = subprocess.run(["pamusb-check", getpass.getuser()], capture_output=True)
+    isAuthenticated = _run_pamusb_check(getpass.getuser())
     if (isAuthenticated.returncode == 0):
         print("OK Pleased to meet you")
         while True:


### PR DESCRIPTION
## Summary
- make `pamusb-pinentry` invoke `/usr/bin/pamusb-check` explicitly instead of resolving `pamusb-check` through `PATH`
- add a small helper for the authentication check command
- add a Python regression test so the command path cannot regress to PATH lookup

Related to the security audit bounty in #55.

## Verification
- `make test-python` (37 Python unit tests passing)
- `git diff --check`
