### PR TITLE
Harden reset-pads path handling

### DIFF
--- a/tests/unit/python/test_pamusb_conf.py
+++ b/tests/unit/python/test_pamusb_conf.py
@@ -10,6 +10,7 @@ Covers:
   - C-2 regression: UUID with shell metacharacters is rejected
   - C-2 regression: UUID with path traversal is rejected
   - C-2 regression: valid UUID is accepted
+  - resetPads uses passwd home directories and an absolute findmnt path
 """
 
 import sys
@@ -222,10 +223,12 @@ def test_reset_pads_processes_all_devices_when_connected(tmp_path):
 
     with patch.object(_mod, "minidom") as mock_mini, \
          patch.object(_mod, "os") as mock_os, \
+         patch.object(_mod, "pwd") as mock_pwd, \
          patch.object(_mod, "subprocess") as mock_sub, \
          patch.object(_mod, "socket") as mock_sock:
 
         mock_mini.parse.return_value = minidom.parseString(_TWO_DEVICE_XML)
+        mock_pwd.getpwnam.return_value.pw_dir = "/srv/home/testuser"
         mock_os.remove.side_effect = lambda p: removed.append(p)
         mock_sub.check_output.side_effect = [b"/mnt/dev1\n", b"/mnt/dev2\n"]
         mock_sub.CalledProcessError = subprocess.CalledProcessError
@@ -237,11 +240,12 @@ def test_reset_pads_processes_all_devices_when_connected(tmp_path):
         with pytest.raises(SystemExit):
             _mod.resetPads()
 
-    assert "/home/testuser/.pamusb/dev1.pad" in removed
-    assert "/home/testuser/.pamusb/dev2.pad" in removed
+    assert "/srv/home/testuser/.pamusb/dev1.pad" in removed
+    assert "/srv/home/testuser/.pamusb/dev2.pad" in removed
     assert "/mnt/dev1/.pamusb/testuser.testhost.pad" in removed
     assert "/mnt/dev2/.pamusb/testuser.testhost.pad" in removed
     assert len(removed) == 4
+    assert mock_sub.check_output.call_args_list[0].args[0][0] == "/usr/bin/findmnt"
 
 
 def test_reset_pads_skips_disconnected_device_atomically(tmp_path):
@@ -250,10 +254,12 @@ def test_reset_pads_skips_disconnected_device_atomically(tmp_path):
 
     with patch.object(_mod, "minidom") as mock_mini, \
          patch.object(_mod, "os") as mock_os, \
+         patch.object(_mod, "pwd") as mock_pwd, \
          patch.object(_mod, "subprocess") as mock_sub, \
          patch.object(_mod, "socket") as mock_sock:
 
         mock_mini.parse.return_value = minidom.parseString(_TWO_DEVICE_XML)
+        mock_pwd.getpwnam.return_value.pw_dir = "/srv/home/testuser"
         mock_os.remove.side_effect = lambda p: removed.append(p)
         mock_sub.check_output.side_effect = [
             b"/mnt/dev1\n",
@@ -268,10 +274,23 @@ def test_reset_pads_skips_disconnected_device_atomically(tmp_path):
         with pytest.raises(SystemExit):
             _mod.resetPads()
 
-    assert "/home/testuser/.pamusb/dev1.pad" in removed
+    assert "/srv/home/testuser/.pamusb/dev1.pad" in removed
     assert "/mnt/dev1/.pamusb/testuser.testhost.pad" in removed
     assert len(removed) == 2
-    assert "/home/testuser/.pamusb/dev2.pad" not in removed
+    assert "/srv/home/testuser/.pamusb/dev2.pad" not in removed
+
+
+def test_reset_pads_rejects_unknown_user():
+    """resetPads should fail before building deletion paths for unknown users."""
+    with patch.object(_mod, "minidom") as mock_mini, \
+         patch.object(_mod, "pwd") as mock_pwd:
+
+        mock_mini.parse.return_value = minidom.parseString(_TWO_DEVICE_XML)
+        mock_pwd.getpwnam.side_effect = KeyError
+        _mod.options = {"configFile": "/fake/conf", "resetPads": "missinguser"}
+
+        with pytest.raises(SystemExit):
+            _mod.resetPads()
 
 
 def _uuid_is_valid(uuid: str) -> bool:

--- a/tools/pamusb-conf
+++ b/tools/pamusb-conf
@@ -22,11 +22,14 @@ import gi
 import subprocess
 import socket
 import getopt
+import pwd
 
 gi.require_version('UDisks', '2.0')
 
 from gi.repository import UDisks
 from xml.dom import minidom
+
+FINDMNT_PATH = '/usr/bin/findmnt'
 
 class Device:
 	def __init__(self, udi):
@@ -333,6 +336,7 @@ def addDevice(options):
 def resetPads():
 	padFiles = []
 	skippedDevices = []
+	userHome = None
 
 	try:
 		doc = minidom.parse(options['configFile'])
@@ -347,6 +351,11 @@ def resetPads():
 	if len(devicesObj) == 0:
 		print('No devices found.')
 		sys.exit(1)
+	try:
+		userHome = pwd.getpwnam(options['resetPads']).pw_dir
+	except KeyError:
+		print('Unable to retrieve information for user "%s".' % options['resetPads'])
+		sys.exit(1)
 
 	alreadyConfiguredUsers = doc.getElementsByTagName('user')
 	if len(alreadyConfiguredUsers) > 0:
@@ -358,7 +367,7 @@ def resetPads():
 						print('Invalid device ID in config (path traversal): %s' % userDevice)
 						sys.exit(1)
 
-					systemPad = '/home/%s/.pamusb/%s.pad' % (options['resetPads'], userDevice)
+					systemPad = '%s/.pamusb/%s.pad' % (userHome.rstrip('/'), userDevice)
 					devicePad = None
 
 					for details in devicesObj:
@@ -369,7 +378,7 @@ def resetPads():
 								sys.exit(1)
 							try:
 								deviceMountPoint = subprocess.check_output(
-									['findmnt', '-n', '-o', 'TARGET', '--source', '/dev/disk/by-uuid/' + deviceUUID],
+									[FINDMNT_PATH, '-n', '-o', 'TARGET', '--source', '/dev/disk/by-uuid/' + deviceUUID],
 									stderr=subprocess.DEVNULL
 								)
 								devicePad = '%s/.pamusb/%s.%s.pad' % (


### PR DESCRIPTION
## Summary
- make `pamusb-conf --reset-pads` use the target user home from `pwd.getpwnam()` instead of hardcoding `/home/<user>`
- fail before constructing deletion paths when the requested user does not exist
- invoke `/usr/bin/findmnt` explicitly instead of resolving `findmnt` through `PATH`
- update reset-pad tests for non-standard home directories, unknown users, and the absolute findmnt path

Related to the security audit bounty in #55.

## Verification
- `make test-python` (37 Python unit tests passing)
- `git diff --check`
