### PR TITLE
Remove hardcoded 10-device limit per user (#236)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,10 +18,4 @@ doc/*.1.gz
 .vscode
 .build
 **/__pycache__
-tests/unit/c/conf_test
-tests/unit/c/pad_test
-tests/unit/c/process_test
-tests/unit/c/tmux_test
-tests/unit/c/xpath_test
-tests/unit/c/evdev_test
-tests/unit/c/remote_services_test
+tests/unit/c/*_test

--- a/src/conf.c
+++ b/src/conf.c
@@ -151,6 +151,16 @@ static int pusb_conf_parse_device(
 	return 1;
 }
 
+void pusb_conf_free(t_pusb_options *opts)
+{
+	if (opts->device_list)
+	{
+		xfree(opts->device_list);
+		opts->device_list = NULL;
+		opts->device_count = 0;
+	}
+}
+
 int pusb_conf_init(t_pusb_options *opts)
 {
 	struct utsname	u;
@@ -189,7 +199,6 @@ int pusb_conf_parse(
 )
 {
 	xmlDoc *doc = NULL;
-	int retval;
 	char device_xpath[sizeof(CONF_USER_XPATH) + CONF_USER_MAXLEN + sizeof("device")];
 
 	log_debug("Parsing settings...\n", user, service);
@@ -210,35 +219,45 @@ int pusb_conf_parse(
 	}
 	snprintf(device_xpath, sizeof(device_xpath), CONF_USER_XPATH, user, "device");
 
-	char *device_list[10] = {
-		xmalloc(128), xmalloc(128), xmalloc(128), xmalloc(128), xmalloc(128),
-		xmalloc(128), xmalloc(128), xmalloc(128), xmalloc(128), xmalloc(128)
-	};
-	for (int currentDevice = 0; currentDevice < 10; currentDevice++)
-	{
-		memset(device_list[currentDevice], 0x0, 128);
-	}
-	retval = pusb_xpath_get_string_list(
-		doc,
-		device_xpath,
-		device_list,
-		sizeof(opts->device.name),
-		10
-	);
-	if (!retval)
+	int n_devices = pusb_xpath_count_nodes(doc, device_xpath);
+	if (n_devices == 0)
 	{
 		log_error("No authentication device(s) configured for user \"%s\".\n", user);
 		xmlFreeDoc(doc);
 		xmlCleanupParser();
-
-		for (int currentDevice = 0; currentDevice < 10; currentDevice++)
-		{
-			xfree(device_list[currentDevice]);
-		}
 		return 0;
 	}
 
-	for (int currentDevice = 0; currentDevice < 10; currentDevice++)
+	char **device_list = xmalloc(n_devices * sizeof(char *));
+	if (!device_list)
+	{
+		log_error("Memory allocation failed\n");
+		xmlFreeDoc(doc);
+		xmlCleanupParser();
+		return 0;
+	}
+	for (int i = 0; i < n_devices; i++)
+	{
+		device_list[i] = xmalloc(128);
+		memset(device_list[i], 0x0, 128);
+	}
+
+	opts->device_list = xmalloc(n_devices * sizeof(t_pusb_device));
+	if (!opts->device_list)
+	{
+		log_error("Memory allocation failed\n");
+		xmlFreeDoc(doc);
+		xmlCleanupParser();
+		for (int i = 0; i < n_devices; i++) xfree(device_list[i]);
+		xfree(device_list);
+		return 0;
+	}
+	memset(opts->device_list, 0x0, n_devices * sizeof(t_pusb_device));
+	opts->device_count = n_devices;
+
+	pusb_xpath_get_string_list(doc, device_xpath, device_list, sizeof(opts->device.name), n_devices);
+
+	for (int currentDevice = 0; currentDevice < n_devices; currentDevice++)
 	{
 		if (device_list[currentDevice] == NULL || strlen(device_list[currentDevice]) == 0)
 		{
@@ -250,11 +269,11 @@ int pusb_conf_parse(
 		{
 			xmlFreeDoc(doc);
 			xmlCleanupParser();
-
-			for (int i = 0; i < 10; i++)
-			{
-				xfree(device_list[i]);
-			}
+			for (int i = 0; i < n_devices; i++) xfree(device_list[i]);
+			xfree(device_list);
+			xfree(opts->device_list);
+			opts->device_list = NULL;
+			opts->device_count = 0;
 			return 0;
 		}
 	}
@@ -269,24 +288,41 @@ int pusb_conf_parse(
 			log_error("Memory allocation failed\n");
 			xmlFreeDoc(doc);
 			xmlCleanupParser();
-			for (int i = 0; i < 10; i++) xfree(device_list[i]);
+			for (int i = 0; i < n_devices; i++) xfree(device_list[i]);
+			xfree(device_list);
+			xfree(opts->device_list);
+			opts->device_list = NULL;
+			opts->device_count = 0;
 			return 0;
 		}
 		snprintf(su_xpath, su_len, CONF_USER_XPATH, user, "device[@superuser='true']");
 
-		char *su_names[10];
-		for (int i = 0; i < 10; i++)
+		char **su_names = xmalloc(n_devices * sizeof(char *));
+		if (!su_names)
+		{
+			log_error("Memory allocation failed\n");
+			xfree(su_xpath);
+			xmlFreeDoc(doc);
+			xmlCleanupParser();
+			for (int i = 0; i < n_devices; i++) xfree(device_list[i]);
+			xfree(device_list);
+			xfree(opts->device_list);
+			opts->device_list = NULL;
+			opts->device_count = 0;
+			return 0;
+		}
+		for (int i = 0; i < n_devices; i++)
 		{
 			su_names[i] = xmalloc(128);
 			memset(su_names[i], 0, 128);
 		}
 
-		if (pusb_xpath_get_string_list(doc, su_xpath, su_names, sizeof(opts->device.name), 10))
+		if (pusb_xpath_get_string_list(doc, su_xpath, su_names, sizeof(opts->device.name), n_devices))
 		{
-			for (int i = 0; i < 10; i++)
+			for (int i = 0; i < n_devices; i++)
 			{
 				if (opts->device_list[i].name[0] == '\0') continue;
-				for (int j = 0; j < 10; j++)
+				for (int j = 0; j < n_devices; j++)
 				{
 					if (su_names[j][0] == '\0') continue;
 					if (strcmp(opts->device_list[i].name, su_names[j]) == 0)
@@ -298,7 +334,8 @@ int pusb_conf_parse(
 			}
 		}
 
-		for (int i = 0; i < 10; i++) xfree(su_names[i]);
+		for (int i = 0; i < n_devices; i++) xfree(su_names[i]);
+		xfree(su_names);
 		xfree(su_xpath);
 	}
 
@@ -306,11 +343,11 @@ int pusb_conf_parse(
 	{
 		xmlFreeDoc(doc);
 		xmlCleanupParser();
-
-		for (int currentDevice = 0; currentDevice < 10; currentDevice++)
-		{
-			xfree(device_list[currentDevice]);
-		}
+		for (int i = 0; i < n_devices; i++) xfree(device_list[i]);
+		xfree(device_list);
+		xfree(opts->device_list);
+		opts->device_list = NULL;
+		opts->device_count = 0;
 		return (0);
 	}
 
@@ -318,7 +355,7 @@ int pusb_conf_parse(
 	if (opts->superuser)
 	{
 		log_debug("Service \"%s\" requires superuser device. Filtering device list.\n", service);
-		for (int i = 0; i < 10; i++)
+		for (int i = 0; i < n_devices; i++)
 		{
 			if (opts->device_list[i].name[0] == '\0') continue;
 			if (!opts->device_list[i].superuser)
@@ -333,9 +370,7 @@ int pusb_conf_parse(
 	xmlFreeDoc(doc);
 	xmlCleanupParser();
 
-	for (int currentDevice = 0; currentDevice < 10; currentDevice++)
-	{
-		xfree(device_list[currentDevice]);
-	}
+	for (int i = 0; i < n_devices; i++) xfree(device_list[i]);
+	xfree(device_list);
 	return (1);
 }

--- a/src/conf.h
+++ b/src/conf.h
@@ -59,7 +59,8 @@ typedef struct		pusb_options
 	char			system_pad_directory[PATH_MAX];
 	char			device_pad_directory[PATH_MAX];
 	t_pusb_device	device;
-	t_pusb_device	device_list[10];
+	t_pusb_device	*device_list;
+	int				device_count;
 	int				superuser;
 }					t_pusb_options;
 
@@ -71,5 +72,6 @@ struct		s_opt_list
 
 int pusb_conf_init(t_pusb_options *opts);
 int pusb_conf_parse(const char *file, t_pusb_options *opts, const char *user, const char *service);
+void pusb_conf_free(t_pusb_options *opts);
 
 #endif /* !PUSB_CONF_H_ */

--- a/src/device.c
+++ b/src/device.c
@@ -35,7 +35,7 @@ static int pusb_device_connected(t_pusb_options *opts, UDisksClient *udisks)
 	UDisksObject *object = NULL;
 	UDisksDrive *drive = NULL;
 
-	for (int currentDevice = 0; currentDevice < 10; currentDevice++)
+	for (int currentDevice = 0; currentDevice < opts->device_count; currentDevice++)
 	{
 		if (strcmp(opts->device_list[currentDevice].name, "") == 0)
 		{
@@ -81,7 +81,7 @@ static int pusb_device_connected(t_pusb_options *opts, UDisksClient *udisks)
 					strncpy(opts->device.model, opts->device_list[currentDevice].model, sizeof(opts->device.model) - 1);
 					strncpy(opts->device.serial, opts->device_list[currentDevice].serial, sizeof(opts->device.serial) - 1);
 					strncpy(opts->device.volume_uuid, opts->device_list[currentDevice].volume_uuid, sizeof(opts->device.volume_uuid) - 1);
-					currentDevice = 10;
+					currentDevice = opts->device_count;
 					break;
 				}
 			}

--- a/src/pam.c
+++ b/src/pam.c
@@ -75,6 +75,7 @@ int pam_sm_authenticate(
 	if (!opts.enable)
 	{
 		log_debug("Not enabled, exiting...\n");
+		pusb_conf_free(&opts);
 		return PAM_IGNORE;
 	}
 
@@ -84,11 +85,13 @@ int pam_sm_authenticate(
 		if (retval != PAM_SUCCESS)
 		{
 			log_error("Unable to retrieve PAM_RHOST.\n");
+			pusb_conf_free(&opts);
 			return PAM_AUTH_ERR;
 		}
 		else if (rhost != NULL && *rhost != '\0')
 		{
 			log_debug("RHOST is set (%s), must be a remote request - disabling myself for this request!\n", rhost);
+			pusb_conf_free(&opts);
 			return PAM_IGNORE;
 		}
 	}
@@ -98,14 +101,17 @@ int pam_sm_authenticate(
 	if (pusb_local_login(&opts, user, service) != 1)
 	{
 		log_error("Access denied.\n");
+		pusb_conf_free(&opts);
 		return PAM_AUTH_ERR;
 	}
 	if (pusb_device_check(&opts, user))
 	{
 		log_info("Access granted.\n");
+		pusb_conf_free(&opts);
 		return PAM_SUCCESS;
 	}
 	log_error("Access denied.\n");
+	pusb_conf_free(&opts);
 	return PAM_AUTH_ERR;
 }
 
@@ -169,6 +175,7 @@ int pam_sm_acct_mgmt(
 	if (!opts.enable)
 	{
 		log_debug("Not enabled, exiting...\n");
+		pusb_conf_free(&opts);
 		return PAM_IGNORE;
 	}
 
@@ -178,11 +185,13 @@ int pam_sm_acct_mgmt(
 		if (retval != PAM_SUCCESS)
 		{
 			log_error("Unable to retrieve PAM_RHOST.\n");
+			pusb_conf_free(&opts);
 			return PAM_AUTH_ERR;
 		}
 		else if (rhost != NULL && *rhost != '\0')
 		{
 			log_debug("RHOST is set (%s), must be a remote request - disabling myself for this request!\n", rhost);
+			pusb_conf_free(&opts);
 			return PAM_IGNORE;
 		}
 	}
@@ -193,14 +202,17 @@ int pam_sm_acct_mgmt(
 	if (pusb_local_login(&opts, user, service) != 1)
 	{
 		log_error("Access denied.\n");
+		pusb_conf_free(&opts);
 		return PAM_AUTH_ERR;
 	}
 	if (pusb_device_check(&opts, user))
 	{
 		log_info("Access granted.\n");
+		pusb_conf_free(&opts);
 		return PAM_SUCCESS;
 	}
 	log_error("Access denied.\n");
+	pusb_conf_free(&opts);
 	return PAM_AUTH_ERR;
 }
 

--- a/src/pamusb-check.c
+++ b/src/pamusb-check.c
@@ -186,7 +186,10 @@ int main(int argc, char **argv)
 	if (dump)
 	{
 		pusb_check_conf_dump(&opts, user, service);
+		pusb_conf_free(&opts);
 		return (1);
 	}
-	return (!pusb_check_perform_authentication(&opts, user, service));
+	int auth_result = pusb_check_perform_authentication(&opts, user, service);
+	pusb_conf_free(&opts);
+	return (!auth_result);
 }

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -131,6 +131,16 @@ int pusb_xpath_get_string(
 	return 1;
 }
 
+int pusb_xpath_count_nodes(xmlDocPtr doc, const char *path)
+{
+	xmlXPathObject *result = pusb_xpath_match(doc, path);
+	if (!result)
+		return 0;
+	int count = result->nodesetval->nodeNr;
+	xmlXPathFreeObject(result);
+	return count;
+}
+
 int pusb_xpath_get_string_list(
 	xmlDocPtr doc,
 	const char *path,

--- a/src/xpath.h
+++ b/src/xpath.h
@@ -21,6 +21,7 @@
 
 int pusb_xpath_get_string(xmlDocPtr doc, const char *path, char *value, size_t size);
 int pusb_xpath_get_string_list(xmlDocPtr doc, const char *path, char *value[], size_t size, int max_count);
+int pusb_xpath_count_nodes(xmlDocPtr doc, const char *path);
 int pusb_xpath_get_string_from(xmlDocPtr doc, const char *base, const char *path, char *value, size_t size);
 int pusb_xpath_get_bool(xmlDocPtr doc, const char *path, int *value);
 int pusb_xpath_get_bool_from(xmlDocPtr doc, const char *base, const char *path, int *value);

--- a/tests/can-actually-be-used/run-tests.sh
+++ b/tests/can-actually-be-used/run-tests.sh
@@ -14,6 +14,7 @@ rm -rf /home/`whoami`/.pamusb
 ./test-conf-doesnt-add-user-twice-but-adds-a-second-device.sh && \
 ./test-check-verify-created-config.sh && \
 ./test-conf-reset-pads.sh && \
+./test-check-many-devices.sh && \
 ./test-check-superuser-filtering.sh && \
 rm -rf /tmp/fakestick/.pamusb && \
 ./test-agent-properly-triggers.sh

--- a/tests/can-actually-be-used/test-check-many-devices.sh
+++ b/tests/can-actually-be-used/test-check-many-devices.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/bash
+
+WHOAMI=$(whoami)
+CONF=/etc/security/pam_usb.conf
+TMP_MANY=/tmp/pam_usb_test_many_devices.conf
+
+# Build 9 fake device definitions and 9 user device refs.
+# Combined with the 2 real devices already in the config, the user will
+# have 11 configured devices — above the old hardcoded limit of 10.
+FAKE_DEVICE_BLOCK=""
+FAKE_REF_BLOCK=""
+for n in $(seq 1 9); do
+    FAKE_DEVICE_BLOCK="${FAKE_DEVICE_BLOCK}<device id=\"fake236_${n}\"><vendor>Fake</vendor><model>Fake</model><serial>FAKE236SERIAL${n}</serial><volume_uuid>FAKE-${n}</volume_uuid></device>"
+    FAKE_REF_BLOCK="${FAKE_REF_BLOCK}<device>fake236_${n}</device>"
+done
+
+sed "s|</devices>|${FAKE_DEVICE_BLOCK}</devices>|" "$CONF" | \
+    sed "s|</user>|${FAKE_REF_BLOCK}</user>|" > "$TMP_MANY"
+
+[ $? -eq 0 ] || { echo "FAILED: could not build temp config"; exit 1; }
+
+# Pre-condition: user must now have more than 10 device refs in the temp config.
+# <device> (closed tag, no attributes) matches only user refs, not device definitions.
+REF_COUNT=$(grep -c "<device>" "$TMP_MANY" || true)
+[ "$REF_COUNT" -gt 10 ] || { echo "FAILED: pre-condition: expected >10 device refs, got ${REF_COUNT}"; rm -f "$TMP_MANY"; exit 1; }
+
+echo -e "Test:\t\t\tpamusb-check grants access when user has more than 10 devices configured"
+# test2 (iSerialNumber=1234567891) is connected; it is entry 2 of 11 in the temp config.
+# This verifies the dynamic device list introduced for issue #236.
+pamusb-check --debug --config="$TMP_MANY" "$WHOAMI" && \
+    echo -e "Result:\t\t\tPASSED!" || \
+    { echo "FAILED: pamusb-check denied access with >10 devices in config"; rm -f "$TMP_MANY"; exit 1; }
+
+rm -f "$TMP_MANY"

--- a/tests/can-actually-be-used/test-check-many-devices.sh
+++ b/tests/can-actually-be-used/test-check-many-devices.sh
@@ -19,10 +19,9 @@ sed "s|</devices>|${FAKE_DEVICE_BLOCK}</devices>|" "$CONF" | \
 
 [ $? -eq 0 ] || { echo "FAILED: could not build temp config"; exit 1; }
 
-# Pre-condition: user must now have more than 10 device refs in the temp config.
-# <device> (closed tag, no attributes) matches only user refs, not device definitions.
-REF_COUNT=$(grep -c "<device>" "$TMP_MANY" || true)
-[ "$REF_COUNT" -gt 10 ] || { echo "FAILED: pre-condition: expected >10 device refs, got ${REF_COUNT}"; rm -f "$TMP_MANY"; exit 1; }
+# Pre-condition: verify that both fake device defs and user refs were injected.
+grep -q "<device>fake236_1</device>" "$TMP_MANY" || { echo "FAILED: pre-condition: fake device refs not found in temp config"; rm -f "$TMP_MANY"; exit 1; }
+grep -q "fake236_9" "$TMP_MANY" || { echo "FAILED: pre-condition: not all fake device defs found in temp config"; rm -f "$TMP_MANY"; exit 1; }
 
 echo -e "Test:\t\t\tpamusb-check grants access when user has more than 10 devices configured"
 # test2 (iSerialNumber=1234567891) is connected; it is entry 2 of 11 in the temp config.

--- a/tests/unit/c/conf_test.c
+++ b/tests/unit/c/conf_test.c
@@ -43,13 +43,14 @@ static void test_superuser_device_present_for_superuser_service(void **state)
 	assert_int_equal(1, pusb_conf_parse(FIXTURE_CONF, &opts, "user_mixed", "sudo"));
 
 	int found_stick2 = 0;
-	for (int i = 0; i < 10; i++) {
+	for (int i = 0; i < opts.device_count; i++) {
 		if (strcmp(opts.device_list[i].name, "stick2") == 0) {
 			found_stick2 = 1;
 			assert_int_equal(1, opts.device_list[i].superuser);
 		}
 	}
 	assert_int_equal(1, found_stick2);
+	pusb_conf_free(&opts);
 }
 
 static void test_nonsuperuser_device_removed_for_superuser_service(void **state)
@@ -59,13 +60,14 @@ static void test_nonsuperuser_device_removed_for_superuser_service(void **state)
 	pusb_conf_init(&opts);
 	assert_int_equal(1, pusb_conf_parse(FIXTURE_CONF, &opts, "user_mixed", "sudo"));
 
-	for (int i = 0; i < 10; i++) {
+	for (int i = 0; i < opts.device_count; i++) {
 		if (opts.device_list[i].name[0] != '\0') {
 			if (strcmp(opts.device_list[i].name, "stick1") == 0) {
 				fail_msg("stick1 (non-superuser) survived superuser filter for sudo service");
 			}
 		}
 	}
+	pusb_conf_free(&opts);
 }
 
 static void test_plain_user_no_superuser_device_gets_empty_list(void **state)
@@ -76,9 +78,10 @@ static void test_plain_user_no_superuser_device_gets_empty_list(void **state)
 	/* user_plain has only stick1, which is not superuser */
 	assert_int_equal(1, pusb_conf_parse(FIXTURE_CONF, &opts, "user_plain", "sudo"));
 
-	for (int i = 0; i < 10; i++) {
+	for (int i = 0; i < opts.device_count; i++) {
 		assert_true(opts.device_list[i].name[0] == '\0');
 	}
+	pusb_conf_free(&opts);
 }
 
 static void test_backward_compat_no_superuser_service(void **state)
@@ -90,12 +93,13 @@ static void test_backward_compat_no_superuser_service(void **state)
 	assert_int_equal(1, pusb_conf_parse(FIXTURE_CONF, &opts, "user_mixed", "login"));
 
 	int found_stick1 = 0, found_stick2 = 0;
-	for (int i = 0; i < 10; i++) {
+	for (int i = 0; i < opts.device_count; i++) {
 		if (strcmp(opts.device_list[i].name, "stick1") == 0) found_stick1 = 1;
 		if (strcmp(opts.device_list[i].name, "stick2") == 0) found_stick2 = 1;
 	}
 	assert_int_equal(1, found_stick1);
 	assert_int_equal(1, found_stick2);
+	pusb_conf_free(&opts);
 }
 
 /* ── Generic vendor/model preservation ── */
@@ -108,7 +112,7 @@ static void test_generic_vendor_model_preserved(void **state)
 	assert_int_equal(1, pusb_conf_parse(FIXTURE_CONF, &opts, "user_generic", "login"));
 
 	int found = 0;
-	for (int i = 0; i < 10; i++) {
+	for (int i = 0; i < opts.device_count; i++) {
 		if (strcmp(opts.device_list[i].name, "stick3") == 0) {
 			found = 1;
 			assert_string_equal("Generic", opts.device_list[i].vendor);
@@ -116,6 +120,7 @@ static void test_generic_vendor_model_preserved(void **state)
 		}
 	}
 	assert_int_equal(1, found);
+	pusb_conf_free(&opts);
 }
 
 /* ── Error paths ── */
@@ -241,10 +246,38 @@ static void test_superuser_attribute_case_sensitive(void **state)
 
 	/* service requires superuser; devA has superuser="TRUE" (case mismatch) so it's
 	   NOT flagged as superuser and must be filtered out */
-	for (int i = 0; i < 10; i++) {
+	for (int i = 0; i < opts.device_count; i++) {
 		assert_true(opts.device_list[i].name[0] == '\0');
 	}
+	pusb_conf_free(&opts);
 	unlink(tmpfile);
+}
+
+/* ── dynamic device count ── */
+
+static void test_conf_parses_more_than_ten_devices(void **state)
+{
+	(void)state;
+	t_pusb_options opts;
+	pusb_conf_init(&opts);
+	assert_int_equal(1, pusb_conf_parse(FIXTURE_CONF, &opts, "user_many", "login"));
+	assert_int_equal(15, opts.device_count);
+
+	int found[15] = {0};
+	char name[128];
+	for (int i = 0; i < opts.device_count; i++) {
+		if (opts.device_list[i].name[0] == '\0') continue;
+		for (int n = 1; n <= 15; n++) {
+			snprintf(name, sizeof(name), "stick%d", n);
+			if (strcmp(opts.device_list[i].name, name) == 0) {
+				found[n - 1] = 1;
+				break;
+			}
+		}
+	}
+	for (int n = 0; n < 15; n++)
+		assert_int_equal(1, found[n]);
+	pusb_conf_free(&opts);
 }
 
 /* ── main ── */
@@ -271,6 +304,7 @@ int main(void)
 		cmocka_unit_test(test_parse_rejects_xpath_device_id_injection),
 		cmocka_unit_test(test_parse_user_not_in_conf),
 		cmocka_unit_test(test_superuser_attribute_case_sensitive),
+		cmocka_unit_test(test_conf_parses_more_than_ten_devices),
 	};
 	return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/tests/unit/c/fixtures/pam_usb_test.conf
+++ b/tests/unit/c/fixtures/pam_usb_test.conf
@@ -19,6 +19,78 @@
 			<serial>SERIAL003</serial>
 			<volume_uuid>3333-CCCC</volume_uuid>
 		</device>
+		<device id="stick4">
+			<vendor>Vendor4</vendor>
+			<model>Model4</model>
+			<serial>SERIAL004</serial>
+			<volume_uuid>4444-DDDD</volume_uuid>
+		</device>
+		<device id="stick5">
+			<vendor>Vendor5</vendor>
+			<model>Model5</model>
+			<serial>SERIAL005</serial>
+			<volume_uuid>5555-EEEE</volume_uuid>
+		</device>
+		<device id="stick6">
+			<vendor>Vendor6</vendor>
+			<model>Model6</model>
+			<serial>SERIAL006</serial>
+			<volume_uuid>6666-FFFF</volume_uuid>
+		</device>
+		<device id="stick7">
+			<vendor>Vendor7</vendor>
+			<model>Model7</model>
+			<serial>SERIAL007</serial>
+			<volume_uuid>7777-0000</volume_uuid>
+		</device>
+		<device id="stick8">
+			<vendor>Vendor8</vendor>
+			<model>Model8</model>
+			<serial>SERIAL008</serial>
+			<volume_uuid>8888-1111</volume_uuid>
+		</device>
+		<device id="stick9">
+			<vendor>Vendor9</vendor>
+			<model>Model9</model>
+			<serial>SERIAL009</serial>
+			<volume_uuid>9999-2222</volume_uuid>
+		</device>
+		<device id="stick10">
+			<vendor>Vendor10</vendor>
+			<model>Model10</model>
+			<serial>SERIAL010</serial>
+			<volume_uuid>AAAA-3333</volume_uuid>
+		</device>
+		<device id="stick11">
+			<vendor>Vendor11</vendor>
+			<model>Model11</model>
+			<serial>SERIAL011</serial>
+			<volume_uuid>BBBB-4444</volume_uuid>
+		</device>
+		<device id="stick12">
+			<vendor>Vendor12</vendor>
+			<model>Model12</model>
+			<serial>SERIAL012</serial>
+			<volume_uuid>CCCC-5555</volume_uuid>
+		</device>
+		<device id="stick13">
+			<vendor>Vendor13</vendor>
+			<model>Model13</model>
+			<serial>SERIAL013</serial>
+			<volume_uuid>DDDD-6666</volume_uuid>
+		</device>
+		<device id="stick14">
+			<vendor>Vendor14</vendor>
+			<model>Model14</model>
+			<serial>SERIAL014</serial>
+			<volume_uuid>EEEE-7777</volume_uuid>
+		</device>
+		<device id="stick15">
+			<vendor>Vendor15</vendor>
+			<model>Model15</model>
+			<serial>SERIAL015</serial>
+			<volume_uuid>FFFF-8888</volume_uuid>
+		</device>
 	</devices>
 	<users>
 		<user id="user_mixed">
@@ -30,6 +102,23 @@
 		</user>
 		<user id="user_generic">
 			<device>stick3</device>
+		</user>
+		<user id="user_many">
+			<device>stick1</device>
+			<device>stick2</device>
+			<device>stick3</device>
+			<device>stick4</device>
+			<device>stick5</device>
+			<device>stick6</device>
+			<device>stick7</device>
+			<device>stick8</device>
+			<device>stick9</device>
+			<device>stick10</device>
+			<device>stick11</device>
+			<device>stick12</device>
+			<device>stick13</device>
+			<device>stick14</device>
+			<device>stick15</device>
 		</user>
 	</users>
 	<services>

--- a/tests/unit/c/xpath_test.c
+++ b/tests/unit/c/xpath_test.c
@@ -211,6 +211,32 @@ static void test_string_list_single(void **state)
 	xmlFreeDoc(doc);
 }
 
+/* ── pusb_xpath_count_nodes ── */
+
+static void test_count_nodes_returns_correct_count(void **state)
+{
+	(void)state;
+	xmlDocPtr doc = make_doc("<r><v>a</v><v>b</v><v>c</v></r>");
+	assert_int_equal(3, pusb_xpath_count_nodes(doc, "//r/v"));
+	xmlFreeDoc(doc);
+}
+
+static void test_count_nodes_returns_zero_for_missing(void **state)
+{
+	(void)state;
+	xmlDocPtr doc = make_doc("<r><v>a</v></r>");
+	assert_int_equal(0, pusb_xpath_count_nodes(doc, "//r/missing"));
+	xmlFreeDoc(doc);
+}
+
+static void test_count_nodes_single_node(void **state)
+{
+	(void)state;
+	xmlDocPtr doc = make_doc("<r><v>only</v></r>");
+	assert_int_equal(1, pusb_xpath_count_nodes(doc, "//r/v"));
+	xmlFreeDoc(doc);
+}
+
 /* ── main ── */
 
 int main(void)
@@ -239,6 +265,9 @@ int main(void)
 		cmocka_unit_test(test_string_zero_size_rejected),
 		cmocka_unit_test(test_string_list_multiple),
 		cmocka_unit_test(test_string_list_single),
+		cmocka_unit_test(test_count_nodes_returns_correct_count),
+		cmocka_unit_test(test_count_nodes_returns_zero_for_missing),
+		cmocka_unit_test(test_count_nodes_single_node),
 	};
 	return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
Replace the fixed `device_list[10]` array in `t_pusb_options` with a dynamically-allocated `*device_list` sized to the exact number of devices found in the config via a new `pusb_xpath_count_nodes()` helper. All iteration loops in conf.c and device.c now use `opts->device_count` instead of the magic number 10.  Add `pusb_conf_free()` to release the allocation; callers in pam.c and pamusb-check.c call it before every return that follows a successful `pusb_conf_parse()`.

Unit tests updated to loop to `opts.device_count`; new tests verify `pusb_xpath_count_nodes` and that a 15-device config is parsed in full.

Closes #236 