### PR TITLE
[Docs] Update manpages to reflect current feature set

### DIFF
--- a/doc/pamusb-agent.1
+++ b/doc/pamusb-agent.1
@@ -33,7 +33,7 @@ Run \fBpamusb-agent\fP in the background.
 \fB--check\fP, \fB-c\fPd
 Set the path to pamusb-check (defaults to /usr/bin/pamusb-check)
 .SH ENVIRONMENT
-\fBpamusb-agent\fP runs event handler commands (\fI<cmd>\fP) as root.
+\fBpamusb-agent\fP runs event handler commands (\fI<cmd>\fP) as the user specified in the configuration (privileges are dropped to that user's UID/GID before execution).
 To prevent privilege escalation via dynamic linker or interpreter injection, the following
 environment variables are stripped from the subprocess environment before execution:
 .PP

--- a/doc/pamusb-agent.1
+++ b/doc/pamusb-agent.1
@@ -1,4 +1,4 @@
-.TH pamusb-agent 1 "August 22, 2022" "" "PAM_USB"
+.TH pamusb-agent 1 "May 2026" "" "PAM_USB"
 
 .SH NAME
 \fBpamusb-agent \fP- pam_usb event handler, triggers configured commands on device removal and/or plug.
@@ -32,6 +32,26 @@ Run \fBpamusb-agent\fP in the background.
 .B
 \fB--check\fP, \fB-c\fPd
 Set the path to pamusb-check (defaults to /usr/bin/pamusb-check)
+.SH ENVIRONMENT
+\fBpamusb-agent\fP runs event handler commands (\fI<cmd>\fP) as root.
+To prevent privilege escalation via dynamic linker or interpreter injection, the following
+environment variables are stripped from the subprocess environment before execution:
+.PP
+.RS
+.TP
+Linker:
+\fBLD_PRELOAD\fP, \fBLD_LIBRARY_PATH\fP, \fBLD_AUDIT\fP, \fBLD_DEBUG\fP, \fBGLIBC_TUNABLES\fP
+.TP
+Interpreters:
+\fBPYTHONPATH\fP, \fBPERL5LIB\fP, \fBRUBYLIB\fP
+.TP
+Shell:
+\fBIFS\fP, \fBCDPATH\fP, \fBENV\fP, \fBBASH_ENV\fP, \fBPATH\fP
+.RE
+.PP
+Any variable not in this blocklist that is declared via \fI<env>\fP in the configuration is passed through unchanged.
+.SH LOGGING
+\fBpamusb-agent\fP logs to syslog using the tag \fIpamusb-agent\fP.
 .SH BUGS
 Please report bugs on the Github issue tracker at https://github.com/mcdope/pam_usb/issues.
 .SH AUTHOR

--- a/doc/pamusb-check.1
+++ b/doc/pamusb-check.1
@@ -1,4 +1,4 @@
-.TH pamusb-check 1 "August 22, 2022" "" "PAM_USB"
+.TH pamusb-check 1 "May 2026" "" "PAM_USB"
 
 .SH NAME
 \fBpamusb-check \fP- check if current pam_usb configuration authenticates given user
@@ -57,8 +57,16 @@ one_time_pad
 : true
 .TP
 .B
+deny_remote
+: true
+.TP
+.B
+pad_expiration
+: 3600 seconds
+.TP
+.B
 probe_timeout
-: 10
+: 10 seconds
 .TP
 .B
 hostname
@@ -96,6 +104,10 @@ Dump the configuration, but do not try to authenticate
 .B
 \fB--quiet\fP, \fB-q\fP
 Quiet mode
+.TP
+.B
+\fB--version\fP
+Print version information and exit.
 .SH BUGS
 Please report bugs on the Github issue tracker at https://github.com/mcdope/pam_usb/issues.
 .SH AUTHOR

--- a/doc/pamusb-conf.1
+++ b/doc/pamusb-conf.1
@@ -1,4 +1,4 @@
-.TH pamusb-conf 1 "August 22, 2022" "" "PAM_USB"
+.TH pamusb-conf 1 "May 2026" "" "PAM_USB"
 
 .SH NAME
 \fBpamusb-conf \fP- pam_usb configuration tool

--- a/doc/pamusb-keyring-unlock-gnome.1
+++ b/doc/pamusb-keyring-unlock-gnome.1
@@ -1,4 +1,4 @@
-.TH pamusb-keyring-unlock-gnome 1 "November 06, 2021" "" "PAM_USB"
+.TH pamusb-keyring-unlock-gnome 1 "May 2026" "" "PAM_USB"
 
 .SH NAME
 \fBpamusb-keyring-unlock-gnome \fP- pam_usb unlock tool for the gnome-keyring
@@ -19,6 +19,11 @@ Removes all files created by \-\-install.
 \fBpamusb-keyring-unlock-gnome\fP is a tool to unlock your GNOME keyring when used with pam_usb autologin.
 .SH CONFIGURATION
 See the pam_usb Wiki <https://github.com/mcdope/pam_usb/wiki/Getting-Started#auto-unlock-your-gnome-keyring> for details about how to configure this feature.
+.SH SECURITY
+The keyring password is passed to \fBgnome-keyring-daemon\fP(1) via a stdin pipe rather than
+as a command-line argument, so it does not appear in the process list.
+.SH LOGGING
+\fBpamusb-keyring-unlock-gnome\fP logs to syslog using the tag \fIpamusb-keyring-unlock-gnome\fP.
 .SH BUGS
 Please post bug reports on the Github issue tracker.
 .SH AUTHOR

--- a/doc/pinentry-pamusb.1
+++ b/doc/pinentry-pamusb.1
@@ -1,4 +1,4 @@
-.TH pinentry-pamusb 1 "November 03, 2024" "" "PAM_USB"
+.TH pinentry-pamusb 1 "May 2026" "" "PAM_USB"
 
 .SH NAME
 \fBpinentry-pamusb \fP- pam_usb tool to be used as pinentry application
@@ -19,7 +19,20 @@ Remove the envfile (\fI~/.pamusb/.pinentry.env\fP) and, if \fBupdate-alternative
 The envfile path is resolved via \fBSUDO_USER\fP when run via sudo.
 The \fBupdate-alternatives\fP step requires root privileges.
 .SH CONFIGURATION
-See the pam_usb Wiki <https://github.com/mcdope/pam_usb/wiki/Getting-Started#auto-unlock-your-gpg-keys> for details about how to configure this feature.
+\fBpinentry-pamusb\fP reads its configuration from \fI~/.pamusb/.pinentry.env\fP (mode 0600,
+created by \fB--install\fP).
+The file is sourced as a shell environment file and supports the following variables:
+.TP
+.B PINENTRY_PASSWORD
+The password that will be returned to \fBgpg-agent\fP(1) via the Assuan protocol when
+pam_usb authentication succeeds.
+.TP
+.B PINENTRY_FALLBACK_APP
+Absolute path to an alternative pinentry program (e.g. \fI/usr/bin/pinentry-gnome3\fP) that
+is invoked when pam_usb authentication fails.
+Must be an absolute path.
+.PP
+For further setup details see the pam_usb Wiki <https://github.com/mcdope/pam_usb/wiki/Getting-Started#auto-unlock-your-gpg-keys>.
 .SH BUGS
 Please post bug reports on the Github issue tracker.
 .SH AUTHOR


### PR DESCRIPTION
## Summary

- Sync all five manpages against current `--help` output, source code, and runtime behaviour that accumulated since the last documentation pass.
- No code changes; documentation only.

## Changes per file

**pamusb-agent.1:** Add `ENVIRONMENT` section documenting the 13 env vars stripped from `<cmd>` subprocesses (LD_PRELOAD family, interpreter paths, shell variables) to prevent privilege escalation. Add `LOGGING` section. Update date.

**pamusb-check.1:** Add `--version` to `OPTIONS`. Add `deny_remote` and `pad_expiration` to the `--dump` example (matches actual binary output). Fix `probe_timeout` / `pad_expiration` to include `"seconds"` suffix. Update date.

**pamusb-conf.1:** Update date only — all options were already documented in a prior pass.

**pamusb-keyring-unlock-gnome.1:** Add `SECURITY` section noting the keyring password is passed via stdin pipe rather than a CLI argument (avoids exposure in `ps`). Add `LOGGING` section. Update date.

**pinentry-pamusb.1:** Expand `CONFIGURATION` section to document `~/.pamusb/.pinentry.env` and both of its variables: `PINENTRY_PASSWORD` and `PINENTRY_FALLBACK_APP`. Update date.

## Why this approach

Manpages are troff source managed directly in the repo (not auto-generated), so each file was updated in place. Changes were cross-checked against the actual binary `--help` output and `src/pamusb-check.c:pusb_check_conf_dump()` to ensure the `--dump` example matches exactly what the binary prints.

## Test plan

- [ ] `man doc/pamusb-agent.1` renders correctly with new ENVIRONMENT and LOGGING sections
- [ ] `man doc/pamusb-check.1` renders correctly with --version and updated --dump example
- [ ] `man doc/pamusb-conf.1` renders correctly
- [ ] `man doc/pamusb-keyring-unlock-gnome.1` renders correctly with new SECURITY and LOGGING sections
- [ ] `man doc/pinentry-pamusb.1` renders correctly with expanded CONFIGURATION section

Closes #340

🤖 This PR was generated with the assistance of Claude Sonnet 4.6

I have read the rules