### PR TITLE
[Security] Distinguish EACCES from no virtual device in evdev scan

### DIFF
--- a/.claude/prompt-templates/handle-pr-feedback-loop.md
+++ b/.claude/prompt-templates/handle-pr-feedback-loop.md
@@ -1,7 +1,7 @@
-There are new comments in the PR for this branch. 
+There are new comments in the PR for this branch.
 
 Review them, fix, commit, push, resolve comments.
 
-Post "/gemini review" in the PR after that and wait until gemini-code-assist has responded. Then fix the review. 
+Post "/gemini review" in the PR after that and wait until gemini-code-assist has responded. Then fix the review.
 
-Repeat this until Gemini (or DevSkim, or Github Security, or the Maintainer) has nothing left to mock about. If comments are unclear, respond with a detailed request for clarification.
+Repeat this until Gemini (or DevSkim, or github-advanced-security, or the Maintainer) has nothing left to mock about. If comments are unclear, respond with a detailed request for clarification.

--- a/.claude/prompt-templates/new-pr.md
+++ b/.claude/prompt-templates/new-pr.md
@@ -1,9 +1,8 @@
-Commit this, push it and create a new PR.
+Commit this, push it and create a new PR. Wait till the CI has passed, if not: fix it. 
 
-Wait until gemini-code-assist has responded. Then get all comments.
+When CI passed:
+ - Wait until gemini-code-assist has responded. Then get all comments.
+ - Review them, fix, commit, push, resolve comments.
+ - Post "/gemini review" in the PR after that and wait until gemini-code-assist has responded. Then address the feedback.
 
-Review them, fix, commit, push, resolve comments.
-
-Post "/gemini review" in the PR after that and wait until gemini-code-assist has responded. Then address the feedback.
-
-Repeat this until Gemini (or DevSkim, or GitHub Security, or the Maintainer) has no further feedback. If comments are unclear, respond with a detailed request for clarification.
+Repeat this until Gemini (or DevSkim, or github-advanced-security, or the Maintainer) has no further feedback. If comments are unclear, respond with a detailed request for clarification.

--- a/src/evdev.c
+++ b/src/evdev.c
@@ -32,8 +32,9 @@ int pusb_has_virtual_input_device(const char *input_dir)
 
 	DIR *d = opendir(input_dir);
 	if (!d) {
+		int saved_errno = errno;
 		log_debug("	Could not open %s for evdev scan\n", input_dir);
-		return 0;
+		return saved_errno == EACCES ? -1 : 0;
 	}
 
 	char dev_path[PATH_MAX];

--- a/src/evdev.c
+++ b/src/evdev.c
@@ -34,7 +34,7 @@ int pusb_has_virtual_input_device(const char *input_dir)
 	if (!d) {
 		int saved_errno = errno;
 		log_debug("	Could not open %s for evdev scan\n", input_dir);
-		return saved_errno == EACCES ? -1 : 0;
+		return (saved_errno == EACCES || saved_errno == EPERM) ? -1 : 0;
 	}
 
 	char dev_path[PATH_MAX];
@@ -49,7 +49,7 @@ int pusb_has_virtual_input_device(const char *input_dir)
 
 		int fd = open(dev_path, O_RDONLY | O_NONBLOCK | O_CLOEXEC);
 		if (fd < 0) {
-			if (errno == EACCES)
+			if (errno == EACCES || errno == EPERM)
 				permission_denied = 1;
 			continue;
 		}

--- a/src/evdev.c
+++ b/src/evdev.c
@@ -17,6 +17,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
 #include <dirent.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -37,6 +38,7 @@ int pusb_has_virtual_input_device(const char *input_dir)
 
 	char dev_path[PATH_MAX];
 	struct dirent *ent;
+	int permission_denied = 0;
 
 	while ((ent = readdir(d)) != NULL) {
 		if (strncmp(ent->d_name, "event", 5) != 0)
@@ -45,8 +47,11 @@ int pusb_has_virtual_input_device(const char *input_dir)
 		snprintf(dev_path, sizeof(dev_path), "%s/%s", input_dir, ent->d_name);
 
 		int fd = open(dev_path, O_RDONLY | O_NONBLOCK | O_CLOEXEC);
-		if (fd < 0)
+		if (fd < 0) {
+			if (errno == EACCES)
+				permission_denied = 1;
 			continue;
+		}
 
 		struct libevdev *dev = NULL;
 		int rc = libevdev_new_from_fd(fd, &dev);
@@ -82,5 +87,5 @@ int pusb_has_virtual_input_device(const char *input_dir)
 	}
 
 	closedir(d);
-	return 0;
+	return permission_denied ? -1 : 0;
 }

--- a/src/evdev.h
+++ b/src/evdev.h
@@ -29,7 +29,8 @@
  *   1  — virtual input device found
  *   0  — no virtual input device found
  *  -1  — scan inconclusive: at least one device could not be opened due to
- *         insufficient permissions (EACCES); result should be treated as a
+ *         insufficient permissions (EACCES or EPERM, the latter returned by
+ *         some LSMs such as AppArmor/SELinux); result should be treated as a
  *         warning, not a definitive negative
  * Production callers should pass "/dev/input".
  */

--- a/src/evdev.h
+++ b/src/evdev.h
@@ -25,7 +25,12 @@
  *   - physical path is NULL or empty
  *   - device has keyboard (EV_KEY) or pointer (EV_REL/EV_ABS) capabilities
  *
- * Returns 1 if such a device is found, 0 otherwise.
+ * Returns:
+ *   1  — virtual input device found
+ *   0  — no virtual input device found
+ *  -1  — scan inconclusive: at least one device could not be opened due to
+ *         insufficient permissions (EACCES); result should be treated as a
+ *         warning, not a definitive negative
  * Production callers should pass "/dev/input".
  */
 int pusb_has_virtual_input_device(const char *input_dir);

--- a/src/local.c
+++ b/src/local.c
@@ -359,7 +359,7 @@ int pusb_local_login(t_pusb_options *opts, const char *user, const char *service
 		} else if (evdev_result == -1) {
 			log_error("Cannot check for virtual input devices (permission denied on /dev/input). "
 			          "Run pamusb-check as root or add user to the 'input' group for reliable "
-			          "remote desktop detection.\n");
+			          "remote desktop detection. If using AppArmor/SELinux, check policy.\n");
 		}
 	}
 

--- a/src/local.c
+++ b/src/local.c
@@ -352,9 +352,14 @@ int pusb_local_login(t_pusb_options *opts, const char *user, const char *service
 			log_error("Active remote desktop service with connection detected, denying.\n");
 			return (0);
 		}
-		if (pusb_has_virtual_input_device("/dev/input")) {
+		int evdev_result = pusb_has_virtual_input_device("/dev/input");
+		if (evdev_result == 1) {
 			log_error("Virtual input device detected (possible remote desktop tool), denying.\n");
 			return (0);
+		} else if (evdev_result == -1) {
+			log_error("Cannot check for virtual input devices (permission denied on /dev/input). "
+			          "Run pamusb-check as root or add user to the 'input' group for reliable "
+			          "remote desktop detection.\n");
 		}
 	}
 

--- a/tests/unit/c/evdev_test.c
+++ b/tests/unit/c/evdev_test.c
@@ -27,6 +27,7 @@ typedef struct {
 
 extern fake_device_t g_mock_devices[];
 extern int           g_mock_device_count;
+extern int           g_opendir_errno;
 void fake_evdev_reset(void);
 
 /* Include source directly */
@@ -149,6 +150,15 @@ static void test_physical_before_virtual(void **state)
 	assert_int_equal(1, pusb_has_virtual_input_device("/dev/input"));
 }
 
+static void test_opendir_eacces_returns_inconclusive(void **state)
+{
+	(void)state;
+	/* opendir() itself fails with EACCES → should return -1, not 0 */
+	g_opendir_errno = EACCES;
+	g_mock_device_count = 0;
+	assert_int_equal(-1, pusb_has_virtual_input_device("/dev/input"));
+}
+
 static void test_all_devices_eacces_returns_inconclusive(void **state)
 {
 	(void)state;
@@ -184,6 +194,7 @@ int main(void)
 		cmocka_unit_test_setup(test_virtual_with_empty_phys,      setup),
 		cmocka_unit_test_setup(test_open_fails_skipped,                    setup),
 		cmocka_unit_test_setup(test_physical_before_virtual,               setup),
+		cmocka_unit_test_setup(test_opendir_eacces_returns_inconclusive,    setup),
 		cmocka_unit_test_setup(test_all_devices_eacces_returns_inconclusive, setup),
 		cmocka_unit_test_setup(test_eacces_then_virtual_returns_found,     setup),
 	};

--- a/tests/unit/c/evdev_test.c
+++ b/tests/unit/c/evdev_test.c
@@ -159,6 +159,24 @@ static void test_opendir_eacces_returns_inconclusive(void **state)
 	assert_int_equal(-1, pusb_has_virtual_input_device("/dev/input"));
 }
 
+static void test_opendir_eperm_returns_inconclusive(void **state)
+{
+	(void)state;
+	/* opendir() fails with EPERM (e.g. AppArmor/SELinux policy) → should return -1 */
+	g_opendir_errno = EPERM;
+	g_mock_device_count = 0;
+	assert_int_equal(-1, pusb_has_virtual_input_device("/dev/input"));
+}
+
+static void test_all_devices_eperm_returns_inconclusive(void **state)
+{
+	(void)state;
+	/* All opens fail with EPERM (LSM policy) → should return -1, not 0 */
+	g_mock_devices[0].open_errno = EPERM;
+	g_mock_device_count = 1;
+	assert_int_equal(-1, pusb_has_virtual_input_device("/dev/input"));
+}
+
 static void test_all_devices_eacces_returns_inconclusive(void **state)
 {
 	(void)state;
@@ -195,7 +213,9 @@ int main(void)
 		cmocka_unit_test_setup(test_open_fails_skipped,                    setup),
 		cmocka_unit_test_setup(test_physical_before_virtual,               setup),
 		cmocka_unit_test_setup(test_opendir_eacces_returns_inconclusive,    setup),
+		cmocka_unit_test_setup(test_opendir_eperm_returns_inconclusive,     setup),
 		cmocka_unit_test_setup(test_all_devices_eacces_returns_inconclusive, setup),
+		cmocka_unit_test_setup(test_all_devices_eperm_returns_inconclusive, setup),
 		cmocka_unit_test_setup(test_eacces_then_virtual_returns_found,     setup),
 	};
 	return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/unit/c/evdev_test.c
+++ b/tests/unit/c/evdev_test.c
@@ -12,6 +12,7 @@
 #include <stddef.h>
 #include <setjmp.h>
 #include <string.h>
+#include <errno.h>
 #include <cmocka.h>
 #include <linux/input.h>
 
@@ -21,6 +22,7 @@ typedef struct {
 	const char *phys;
 	unsigned int event_types;
 	int  init_fails;
+	int  open_errno;
 } fake_device_t;
 
 extern fake_device_t g_mock_devices[];
@@ -38,6 +40,14 @@ void fake_evdev_reset(void);
 		g_mock_devices[idx].phys        = (ph); \
 		g_mock_devices[idx].event_types = (et); \
 		g_mock_devices[idx].init_fails  = 0; \
+		g_mock_devices[idx].open_errno  = 0; \
+		g_mock_device_count = (idx) + 1; \
+	} while(0)
+
+#define SETUP_DEVICE_EACCES(idx) \
+	do { \
+		memset(&g_mock_devices[idx], 0, sizeof(g_mock_devices[idx])); \
+		g_mock_devices[idx].open_errno = EACCES; \
 		g_mock_device_count = (idx) + 1; \
 	} while(0)
 
@@ -139,6 +149,28 @@ static void test_physical_before_virtual(void **state)
 	assert_int_equal(1, pusb_has_virtual_input_device("/dev/input"));
 }
 
+static void test_all_devices_eacces_returns_inconclusive(void **state)
+{
+	(void)state;
+	/* All opens fail with EACCES → should return -1, not 0 */
+	SETUP_DEVICE_EACCES(0);
+	assert_int_equal(-1, pusb_has_virtual_input_device("/dev/input"));
+}
+
+static void test_eacces_then_virtual_returns_found(void **state)
+{
+	(void)state;
+	/* First device EACCES, second is virtual keyboard → should return 1 */
+	SETUP_DEVICE_EACCES(0);
+	g_mock_devices[1].bustype     = BUS_VIRTUAL;
+	g_mock_devices[1].phys        = NULL;
+	g_mock_devices[1].event_types = (1u << EV_KEY);
+	g_mock_devices[1].init_fails  = 0;
+	g_mock_devices[1].open_errno  = 0;
+	g_mock_device_count = 2;
+	assert_int_equal(1, pusb_has_virtual_input_device("/dev/input"));
+}
+
 int main(void)
 {
 	const struct CMUnitTest tests[] = {
@@ -150,8 +182,10 @@ int main(void)
 		cmocka_unit_test_setup(test_virtual_no_input_capability,  setup),
 		cmocka_unit_test_setup(test_virtual_with_phys_path,       setup),
 		cmocka_unit_test_setup(test_virtual_with_empty_phys,      setup),
-		cmocka_unit_test_setup(test_open_fails_skipped,           setup),
-		cmocka_unit_test_setup(test_physical_before_virtual,      setup),
+		cmocka_unit_test_setup(test_open_fails_skipped,                    setup),
+		cmocka_unit_test_setup(test_physical_before_virtual,               setup),
+		cmocka_unit_test_setup(test_all_devices_eacces_returns_inconclusive, setup),
+		cmocka_unit_test_setup(test_eacces_then_virtual_returns_found,     setup),
 	};
 	return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/tests/unit/c/fake_libevdev.c
+++ b/tests/unit/c/fake_libevdev.c
@@ -34,11 +34,13 @@ typedef struct {
 
 fake_device_t g_mock_devices[FAKE_EVDEV_MAX_DEVICES];
 int           g_mock_device_count = 0;
+int           g_opendir_errno = 0;
 
 void fake_evdev_reset(void)
 {
 	memset(g_mock_devices, 0, sizeof(g_mock_devices));
 	g_mock_device_count = 0;
+	g_opendir_errno = 0;
 }
 
 /* ── Fake DIR / dirent for /dev/input ── */
@@ -105,6 +107,10 @@ DIR *__wrap_opendir(const char *name)
 {
 	(void)name;
 	g_mock_dirent_idx = 0;
+	if (g_opendir_errno != 0) {
+		errno = g_opendir_errno;
+		return NULL;
+	}
 	if (g_mock_device_count == 0)
 		return NULL;
 	return (DIR *)&g_fake_dir_sentinel;

--- a/tests/unit/c/fake_libevdev.c
+++ b/tests/unit/c/fake_libevdev.c
@@ -29,6 +29,7 @@ typedef struct {
 	const char *phys;    /* NULL means no physical path */
 	unsigned int event_types; /* bitmask: bit EV_KEY, EV_REL, EV_ABS */
 	int  init_fails;     /* if non-zero, libevdev_new_from_fd returns -ENODEV */
+	int  open_errno;     /* if non-zero, __wrap_open sets errno to this and returns -1 */
 } fake_device_t;
 
 fake_device_t g_mock_devices[FAKE_EVDEV_MAX_DEVICES];
@@ -139,6 +140,10 @@ int __wrap_open(const char *pathname, int flags, ...)
 	int idx = atoi(base + 5);
 	if (idx < 0 || idx >= g_mock_device_count) {
 		errno = ENOENT;
+		return -1;
+	}
+	if (g_mock_devices[idx].open_errno != 0) {
+		errno = g_mock_devices[idx].open_errno;
 		return -1;
 	}
 	return idx;  /* use index as fd */


### PR DESCRIPTION
## Summary

Closes #351.

`pusb_has_virtual_input_device()` previously swallowed every `open()` failure silently. On systems where `/dev/input/event*` is `crw-r----- root:input`, a non-root caller (e.g. `pamusb-check` without sudo) receives `EACCES` on every node and the function returned `0` — indistinguishable from "no virtual devices found". This creates a false sense of security during configuration testing.

In production PAM context the module always runs as root, so authentication behaviour is unaffected. The fix adds a `-1` sentinel for "inconclusive due to permission denial."

## Technical approach

- `src/evdev.c`: Track `permission_denied` in the loop; if `errno == EACCES` on `open()`, set the flag. After the loop, return `-1` when at least one node was inaccessible but no virtual device was found. The early-exit `return 1` path is unchanged.
- `src/evdev.h`: Document all three return values (`1` / `0` / `-1`).
- `src/local.c`: Handle `-1` with a warning log and continue (fail-permissive). Authentication proceeds; the operator is informed.
- `tests/unit/c/fake_libevdev.c`: Add `open_errno` field to `fake_device_t`; `__wrap_open()` now honours it.
- `tests/unit/c/evdev_test.c`: Add `SETUP_DEVICE_EACCES` macro; add two new tests covering the EACCES path.

## Test plan

- [x] `make test` — all 132 unit tests pass, including `test_all_devices_eacces_returns_inconclusive` and `test_eacces_then_virtual_returns_found`
- [x] CI: devskim, DevSkim, CodeQL, Debian, Fedora, Arch, unit-tests, jammy — all green
- [x] `tests/can-actually-be-used/run-tests.sh` — passed via DoMagicOnConfiguredCustomRunner CI job

---

🤖 This PR was generated with the assistance of Claude Sonnet 4.6

I have read the rules