### PR TITLE
Prepare 0.9.1 release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+* 0.9.1
+  [Bugfix] Restore debug output suppressed before config parsing; fix XRDP detection log message (#355)
+  [Security] Fixed GHSA-qg76-57wq-mpv6 (thread-unsafe static pointer in log.c) (#355)
+  [Security] Fixed GHSA-24mw-m2vf-36vp (integer overflow before heap allocation in conf.c) (#359)
+  [Security] Fixed GHSA-pvrg-chgw-x42c (evdev scan silently discards EACCES under non-root) (#360)
+  [Security] Fixed GHSA-w38v-cw9r-x9p6 (PAM_RHOST check skipped when deny_remote=false) (#361)
+  [CI/Tests] Add regression tests for thread-safe log.c (#357)
+  [Refactor] Deduplicate pam_sm_authenticate / pam_sm_acct_mgmt in pam.c (#356)
+
 * 0.9.0
   [Feature] Remove hardcoded 10-device limit per user (#236)
   [Feature] Add additional remote connection check for VNC/RDP (optional, default on) (#202)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ At every point in time only the most recent release is supported.
 
 | Version | Supported          |
 |---------| ------------------ |
-| 0.9.0   | ✅                 |
-| < 0.9.0 | ❌                 |
+| 0.9.1   | ✅                 |
+| < 0.9.1 | ❌                 |
 
 ## Reporting a Vulnerability
 
@@ -29,4 +29,4 @@ Once a vulnerability has been reported via email and coordinated with the mainta
 
 There are multiple published security advisories for these versions.
 
-If you're running anything except 0.9.0 please update immediately!
+If you're running anything except 0.9.1 please update immediately!

--- a/arch_linux/PKGBUILD_stable
+++ b/arch_linux/PKGBUILD_stable
@@ -2,7 +2,7 @@
 # Contributor: Pekka Helenius <fincer89 [at] hotmail [dot] com>
 
 pkgname=pam_usb
-pkgver=0.9.0
+pkgver=0.9.1
 pkgrel=1
 pkgdesc='Hardware authentication for Linux using ordinary flash media (USB & Card based).'
 arch=($CARCH)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+libpam-usb (0.9.1) unstable; urgency=high
+
+  * [Bugfix] Restore debug output suppressed before config parsing; fix XRDP detection log message (#355)
+  * [Security] Fixed GHSA-qg76-57wq-mpv6 (thread-unsafe static pointer in log.c) (#355)
+  * [Security] Fixed GHSA-24mw-m2vf-36vp (integer overflow before heap allocation in conf.c) (#359)
+  * [Security] Fixed GHSA-pvrg-chgw-x42c (evdev scan silently discards EACCES under non-root) (#360)
+  * [Security] Fixed GHSA-w38v-cw9r-x9p6 (PAM_RHOST check skipped when deny_remote=false) (#361)
+  * [CI/Tests] Add regression tests for thread-safe log.c (#357)
+  * [Refactor] Deduplicate pam_sm_authenticate / pam_sm_acct_mgmt in pam.c (#356)
+
+ -- Tobias Bäumer <tobiasbaeumer@gmail.com>  Wed, 20 May 2026 00:00:00 +0200
+
 libpam-usb (0.9.0) unstable; urgency=critical
   * [Feature] Remove hardcoded 10-device limit per user (#236)
   * [Feature] Add additional remote connection check for VNC/RDP (optional, default on) (#202)

--- a/fedora/SPECS/pam_usb.spec
+++ b/fedora/SPECS/pam_usb.spec
@@ -1,7 +1,7 @@
 %define _topdir         /usr/local/src/pam_usb/fedora
 %define name            pam_usb 
 %define release         1
-%define version         0.9.0
+%define version         0.9.1
 %define buildroot       %{_topdir}/%{name}‑%{version}‑root
 
 BuildRoot: %{buildroot}
@@ -61,6 +61,15 @@ rm -rf %{buildroot}/usr/share/pam-configs
 %doc %attr(0644,root,root) /usr/share/doc/pam_usb/TROUBLESHOOTING
 
 %changelog
+
+* Wed May 20 2026 Tobias Bäumer <tobiasbaeumer@gmail.com> - 0.9.1
+- [Bugfix] Restore debug output suppressed before config parsing; fix XRDP detection log message (#355)
+- [Security] Fixed GHSA-qg76-57wq-mpv6 (thread-unsafe static pointer in log.c) (#355)
+- [Security] Fixed GHSA-24mw-m2vf-36vp (integer overflow before heap allocation in conf.c) (#359)
+- [Security] Fixed GHSA-pvrg-chgw-x42c (evdev scan silently discards EACCES under non-root) (#360)
+- [Security] Fixed GHSA-w38v-cw9r-x9p6 (PAM_RHOST check skipped when deny_remote=false) (#361)
+- [CI/Tests] Add regression tests for thread-safe log.c (#357)
+- [Refactor] Deduplicate pam_sm_authenticate / pam_sm_acct_mgmt in pam.c (#356)
 
 * Tue May 19 2026 Tobias Bäumer <tobiasbaeumer@gmail.com> - 0.9.0
 - [Feature] Remove hardcoded 10-device limit per user (#236)

--- a/src/version.h
+++ b/src/version.h
@@ -18,6 +18,6 @@
 #ifndef PUSB_VERSION_H_
 # define PUSB_VERSION_H_
 
-# define PUSB_VERSION "0.9.0"
+# define PUSB_VERSION "0.9.1"
 
 #endif /* !PUSB_VERSION_H_ */

--- a/tools/pamusb-conf
+++ b/tools/pamusb-conf
@@ -421,7 +421,7 @@ def resetPads():
 	sys.exit(0)
 
 def usage():
-	print('Version 0.9.0')
+	print('Version 0.9.1')
 	print('Usage: %s [--help] [--verbose] [--yes] [--config=path] [--reset-pads=username]' % os.path.basename(__file__))
 	print('                [[--add-user=name [--superuser]] | [--add-device=name [[--device=number] [--volume=number]]]]')
 	sys.exit(1)


### PR DESCRIPTION
## Summary

Security patch release bumping all version strings, changelogs, and packaging metadata from 0.9.0 to 0.9.1.

## Checklist (issue #362)

- [x] Check & Update Wiki — no changes needed (no new features/options in 0.9.1)
- [x] Check & Update Manpages — no changes needed (no new features/options in 0.9.1)
- [x] Update AUTHORS — no new contributors since 0.9.0
- [x] Update CHANGELOG
- [x] Update Debian changelog
- [x] Update Fedora changelog
- [x] Update Arch PKGBUILD versions
- [x] Update version.h
- [x] Update version in pamusb-conf
- [x] Update SECURITY.md version numbers
- [ ] Add tag "major.minor.patch" after merging prep PR (MANUALLY!)

## Changes since 0.9.0

- [Bugfix] Restore debug output suppressed before config parsing; fix XRDP detection log message (#355)
- [Security] Fixed GHSA-qg76-57wq-mpv6 (thread-unsafe static pointer in log.c) (#355)
- [Security] Fixed GHSA-24mw-m2vf-36vp (integer overflow before heap allocation in conf.c) (#359)
- [Security] Fixed GHSA-pvrg-chgw-x42c (evdev scan silently discards EACCES under non-root) (#360)
- [Security] Fixed GHSA-w38v-cw9r-x9p6 (PAM_RHOST check skipped when deny_remote=false) (#361)
- [CI/Tests] Add regression tests for thread-safe log.c (#357)
- [Refactor] Deduplicate pam_sm_authenticate / pam_sm_acct_mgmt in pam.c (#356)

Closes #362

---
🤖 This PR was generated with the assistance of Claude Sonnet 4.6

I have read the rules