### PR TITLE
[Security] Add O_NOFOLLOW to evdev open() to prevent symlink following (issue #369)

### DIFF
--- a/src/evdev.c
+++ b/src/evdev.c
@@ -48,7 +48,7 @@ int pusb_has_virtual_input_device(const char *input_dir)
 
 		snprintf(dev_path, sizeof(dev_path), "%s/%s", input_dir, ent->d_name);
 
-		int fd = open(dev_path, O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+		int fd = open(dev_path, O_RDONLY | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW);
 		if (fd < 0) {
 			if (errno == EACCES || errno == EPERM)
 				permission_denied = 1;

--- a/tests/unit/c/evdev_test.c
+++ b/tests/unit/c/evdev_test.c
@@ -53,6 +53,13 @@ void fake_evdev_reset(void);
 		g_mock_device_count = (idx) + 1; \
 	} while(0)
 
+#define SETUP_DEVICE_ELOOP(idx) \
+	do { \
+		memset(&g_mock_devices[idx], 0, sizeof(g_mock_devices[idx])); \
+		g_mock_devices[idx].open_errno = ELOOP; \
+		g_mock_device_count = (idx) + 1; \
+	} while(0)
+
 static int setup(void **state)
 {
 	(void)state;
@@ -200,6 +207,28 @@ static void test_eacces_then_virtual_returns_found(void **state)
 	assert_int_equal(1, pusb_has_virtual_input_device("/dev/input"));
 }
 
+static void test_symlink_device_skipped(void **state)
+{
+	(void)state;
+	/* O_NOFOLLOW rejects a symlink → ELOOP → device skipped, result is 0 (not inconclusive) */
+	SETUP_DEVICE_ELOOP(0);
+	assert_int_equal(0, pusb_has_virtual_input_device("/dev/input"));
+}
+
+static void test_symlink_then_virtual_detected(void **state)
+{
+	(void)state;
+	/* First device is a symlink (ELOOP), second is a real virtual keyboard → still detected */
+	SETUP_DEVICE_ELOOP(0);
+	g_mock_devices[1].bustype     = BUS_VIRTUAL;
+	g_mock_devices[1].phys        = NULL;
+	g_mock_devices[1].event_types = (1u << EV_KEY);
+	g_mock_devices[1].init_fails  = 0;
+	g_mock_devices[1].open_errno  = 0;
+	g_mock_device_count = 2;
+	assert_int_equal(1, pusb_has_virtual_input_device("/dev/input"));
+}
+
 int main(void)
 {
 	const struct CMUnitTest tests[] = {
@@ -218,6 +247,8 @@ int main(void)
 		cmocka_unit_test_setup(test_all_devices_eacces_returns_inconclusive, setup),
 		cmocka_unit_test_setup(test_all_devices_eperm_returns_inconclusive, setup),
 		cmocka_unit_test_setup(test_eacces_then_virtual_returns_found,     setup),
+		cmocka_unit_test_setup(test_symlink_device_skipped,               setup),
+		cmocka_unit_test_setup(test_symlink_then_virtual_detected,        setup),
 	};
 	return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/tests/unit/c/evdev_test.c
+++ b/tests/unit/c/evdev_test.c
@@ -55,9 +55,10 @@ void fake_evdev_reset(void);
 
 #define SETUP_DEVICE_ELOOP(idx) \
 	do { \
-		memset(&g_mock_devices[idx], 0, sizeof(g_mock_devices[idx])); \
-		g_mock_devices[idx].open_errno = ELOOP; \
-		g_mock_device_count = (idx) + 1; \
+		int _idx = (idx); \
+		memset(&g_mock_devices[_idx], 0, sizeof(g_mock_devices[_idx])); \
+		g_mock_devices[_idx].open_errno = ELOOP; \
+		g_mock_device_count = _idx + 1; \
 	} while(0)
 
 static int setup(void **state)

--- a/tests/unit/c/evdev_test.c
+++ b/tests/unit/c/evdev_test.c
@@ -220,12 +220,7 @@ static void test_symlink_then_virtual_detected(void **state)
 	(void)state;
 	/* First device is a symlink (ELOOP), second is a real virtual keyboard → still detected */
 	SETUP_DEVICE_ELOOP(0);
-	g_mock_devices[1].bustype     = BUS_VIRTUAL;
-	g_mock_devices[1].phys        = NULL;
-	g_mock_devices[1].event_types = (1u << EV_KEY);
-	g_mock_devices[1].init_fails  = 0;
-	g_mock_devices[1].open_errno  = 0;
-	g_mock_device_count = 2;
+	SETUP_DEVICE(1, BUS_VIRTUAL, NULL, (1u << EV_KEY));
 	assert_int_equal(1, pusb_has_virtual_input_device("/dev/input"));
 }
 


### PR DESCRIPTION
## Summary

`src/evdev.c` opened `/dev/input/event*` device nodes without `O_NOFOLLOW`. If a
device node is replaced by a symbolic link — via a rogue udev rule or a TOCTOU race
between device enumeration and open — `open()` would silently follow the symlink and
open its target instead of failing.

Adding `O_NOFOLLOW` causes `open()` to return `-1` with `errno == ELOOP` when the
final path component is a symbolic link. The existing error handling already skips
entries where `open()` fails and `errno` is neither `EACCES` nor `EPERM`, so `ELOOP`
is handled correctly without any additional code: the symlink is rejected and the scan
continues. Intentionally, `ELOOP` does **not** set `permission_denied` — a symlink is
a rejected-by-policy path, not a permissions failure.

Closes #369. Refs GHSA-pvrg-chgw-x42c.

## Technical approach

One-flag addition to the `open()` call in the evdev scan loop:

```c
// Before
int fd = open(dev_path, O_RDONLY | O_NONBLOCK | O_CLOEXEC);

// After
int fd = open(dev_path, O_RDONLY | O_NONBLOCK | O_CLOEXEC | O_NOFOLLOW);
```

`O_NOFOLLOW` is POSIX.1-2008 / Linux since 2.1.126 — no portability concern for
this project.

## Tests

Two new tests in `tests/unit/c/evdev_test.c` using the existing `__wrap_open`
infrastructure (which already supports arbitrary `open_errno` values):

- `test_symlink_device_skipped` — single device with `open_errno = ELOOP` → scan
  returns `0` (not inconclusive; symlink is simply skipped)
- `test_symlink_then_virtual_detected` — first device is ELOOP, second is a real
  virtual keyboard → scan returns `1` (detection still works after a rejected symlink)

`make test` passes locally (229 tests: 171 C unit + 58 Python).

## Security rationale

CWE-59 (Improper Link Resolution Before File Access). While the immediate impact of
symlink-following here is limited to misrouted `ioctl` calls, the absence of
`O_NOFOLLOW` on device-node opens in security-sensitive code is a well-established
hardening gap. Applying it now is low-risk and prevents the gap from becoming
exploitable if future code changes add more operations on the opened fd.

🤖 This PR was generated with the assistance of Claude Sonnet 4.6

I have read the rules