### PR TITLE
[Docs] Clarify PR feedback prompt templates

### DIFF
--- a/.claude/prompt-templates/handle-pr-feedback-loop.md
+++ b/.claude/prompt-templates/handle-pr-feedback-loop.md
@@ -1,7 +1,7 @@
 There are new comments in the PR for this branch.
 
-Review them, fix, commit, push, resolve comments.
+Review them, fix, commit, push, resolve comments  (note that you must answer each comment, even if repetitive).
 
 Post "/gemini review" in the PR after that and wait until gemini-code-assist has responded. Then fix the review.
 
-Repeat this until Gemini (or DevSkim, or github-advanced-security, or the Maintainer) has nothing left to mock about. If comments are unclear, respond with a detailed request for clarification.
+Repeat this until gemini-code-assist (or DevSkim, or github-advanced-security, or the Maintainer) has nothing left to mock about. If comments are unclear, respond with a detailed request for clarification.

--- a/.claude/prompt-templates/handle-pr-feedback-loop.md
+++ b/.claude/prompt-templates/handle-pr-feedback-loop.md
@@ -4,4 +4,4 @@ Review them, fix, commit, push, resolve comments (note that you must answer each
 
 Post "/gemini review" in the PR after that and wait until gemini-code-assist has responded. Then fix the review.
 
-Repeat this until gemini-code-assist (or DevSkim, or github-advanced-security, or the Maintainer) has nothing left to mock about. If comments are unclear, respond with a detailed request for clarification.
+Repeat this until gemini-code-assist (or DevSkim, or github-advanced-security, or the Maintainer) has no further feedback. If comments are unclear, respond with a detailed request for clarification.

--- a/.claude/prompt-templates/handle-pr-feedback-loop.md
+++ b/.claude/prompt-templates/handle-pr-feedback-loop.md
@@ -1,6 +1,6 @@
 There are new comments in the PR for this branch.
 
-Review them, fix, commit, push, resolve comments  (note that you must answer each comment, even if repetitive).
+Review them, fix, commit, push, resolve comments (note that you must answer each comment, even if repetitive).
 
 Post "/gemini review" in the PR after that and wait until gemini-code-assist has responded. Then fix the review.
 

--- a/.claude/prompt-templates/handle-pr-feedback.md
+++ b/.claude/prompt-templates/handle-pr-feedback.md
@@ -1,5 +1,5 @@
 There are new comments in the PR for this branch.
 
-Review them, fix, commit, push, resolve comments.
+Review them, fix, commit, push, resolve comments (note that you must answer each comment, even if repetitive).
 
 Post "/gemini review" in the PR after that.

--- a/.claude/prompt-templates/new-pr.md
+++ b/.claude/prompt-templates/new-pr.md
@@ -1,8 +1,8 @@
-Commit this, push it and create a new PR. Wait till the CI has passed, if not: fix it. 
+Commit this, push it and create a new PR. Wait till the CI has passed, if not: fix it.
 
 When CI passed:
- - Wait until gemini-code-assist has responded. Then get all comments.
- - Review them, fix, commit, push, resolve comments.
- - Post "/gemini review" in the PR after that and wait until gemini-code-assist has responded. Then address the feedback.
+- Wait until gemini-code-assist has responded. Then get all comments.
+- Review them, fix, commit, push, resolve comments (note that you must answer each comment, even if repetitive).
+- Post "/gemini review" in the PR after that and wait until gemini-code-assist has responded. Then address the feedback.
 
-Repeat this until Gemini (or DevSkim, or github-advanced-security, or the Maintainer) has no further feedback. If comments are unclear, respond with a detailed request for clarification.
+Repeat this until gemini-code-assist (or DevSkim, or github-advanced-security, or the Maintainer) has no further feedback. If comments are unclear, respond with a detailed request for clarification.


### PR DESCRIPTION
Add reminder to answer each review comment even when repetitive; normalise "Gemini" references to "gemini-code-assist"; fix list indentation in new-pr.md.