### PR TITLE
[Security] Add compiler and linker hardening flags (issue #366)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,15 @@ endif
 
 # compiler/linker options
 CC := gcc
-CFLAGS := $(CFLAGS) -Wall -fPIC `pkg-config --cflags libxml-2.0` `pkg-config --cflags udisks2` `pkg-config --cflags libevdev` #cflags libxml?
-ifeq (yes, ${DEBUG})
-	CFLAGS := ${CFLAGS} -ggdb
+CFLAGS := $(CFLAGS) -Wall -O2 -fPIC -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fstack-clash-protection -fno-plt -fzero-call-used-regs=used-gpr -Wformat=2 `pkg-config --cflags libxml-2.0` `pkg-config --cflags udisks2` `pkg-config --cflags libevdev` #cflags libxml?
+ifeq ($(ARCH), x86_64)
+	CFLAGS := $(CFLAGS) -fcf-protection=full
 endif
+ifeq (yes, ${DEBUG})
+	CFLAGS := ${CFLAGS} -O0 -ggdb
+endif
+
+HARDENING_LDFLAGS := -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack
 
 LIBS := `pkg-config --libs libxml-2.0` `pkg-config --libs udisks2` `pkg-config --libs libevdev`
 
@@ -56,7 +61,7 @@ OBJS := $(SRCS:.c=.o)
 PAM_USB_SRCS := src/pam.c
 PAM_USB_OBJS := $(PAM_USB_SRCS:.c=.o)
 PAM_USB	:= pam_usb.so
-PAM_USB_LDFLAGS := -shared
+PAM_USB_LDFLAGS := -shared $(HARDENING_LDFLAGS)
 PAM_USB_DEST := $(DESTDIR)/$(LIBDIR)/security
 
 # pamusb-check
@@ -168,7 +173,7 @@ test-c-log: tests/unit/c/log_test.c src/log.c
 
 test-c-mem: tests/unit/c/mem_test.c src/mem.c src/log.o
 	$(CC) $(TEST_CFLAGS) tests/unit/c/mem_test.c src/log.o \
-		-Wl,--wrap=explicit_bzero \
+		-Wl,--wrap=explicit_bzero,--wrap=__explicit_bzero_chk \
 		$(MEM_LDFLAGS) -o tests/unit/c/mem_test
 	./tests/unit/c/mem_test
 
@@ -185,7 +190,7 @@ $(PAM_USB): $(OBJS) $(PAM_USB_OBJS)
 	$(CC) -o $(PAM_USB) $(PAM_USB_LDFLAGS) $(LDFLAGS) $(OBJS) $(PAM_USB_OBJS) $(LIBS)
 
 $(PAMUSB_CHECK): $(OBJS) $(PAMUSB_CHECK_OBJS)
-	$(CC) -o $(PAMUSB_CHECK) $(LDFLAGS) $(OBJS) $(PAMUSB_CHECK_OBJS) $(LIBS)
+	$(CC) -o $(PAMUSB_CHECK) $(LDFLAGS) $(HARDENING_LDFLAGS) -pie $(OBJS) $(PAMUSB_CHECK_OBJS) $(LIBS)
 
 %.o: %.c
 	${CC} -c ${CFLAGS} $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ ifeq ($(ARCH), x86_64)
 	CFLAGS := $(CFLAGS) -fcf-protection=full
 endif
 ifeq (yes, ${DEBUG})
-	CFLAGS := ${CFLAGS} -O0 -ggdb
+	CFLAGS := ${CFLAGS} -O0 -U_FORTIFY_SOURCE -ggdb
 endif
 
 HARDENING_LDFLAGS := -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,12 @@ endif
 
 # compiler/linker options
 CC := gcc
-CFLAGS := $(CFLAGS) -Wall -O2 -fPIC -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fstack-clash-protection -fno-plt -fzero-call-used-regs=used-gpr -Wformat=2 `pkg-config --cflags libxml-2.0` `pkg-config --cflags udisks2` `pkg-config --cflags libevdev` #cflags libxml?
+CFLAGS := $(CFLAGS) -Wall -O2 -fPIC -fstack-protector-strong -D_FORTIFY_SOURCE=2 -fstack-clash-protection -fno-plt -Wformat=2 `pkg-config --cflags libxml-2.0` `pkg-config --cflags udisks2` `pkg-config --cflags libevdev` #cflags libxml?
+# -fzero-call-used-regs requires GCC >= 11; probe at configure time
+ZERO_REGS_SUPPORTED := $(shell $(CC) -fzero-call-used-regs=used-gpr -E - < /dev/null 2>/dev/null && echo yes)
+ifeq ($(ZERO_REGS_SUPPORTED), yes)
+	CFLAGS := $(CFLAGS) -fzero-call-used-regs=used-gpr
+endif
 ifeq ($(ARCH), x86_64)
 	CFLAGS := $(CFLAGS) -fcf-protection=full
 endif

--- a/src/conf.c
+++ b/src/conf.c
@@ -206,12 +206,12 @@ int pusb_conf_parse(
 	xmlDoc *doc = NULL;
 	char device_xpath[sizeof(CONF_USER_XPATH) + CONF_USER_MAXLEN + sizeof("device")];
 
-	log_debug("Parsing settings for user \"%s\", service \"%s\"...\n", user, service);
 	if (!pusb_conf_xpath_id_is_safe("Username", user) ||
 	    !pusb_conf_xpath_id_is_safe("Service", service))
 	{
 		return 0;
 	}
+	log_debug("Parsing settings for user \"%s\", service \"%s\"...\n", user, service);
 	if (strlen(user) > CONF_USER_MAXLEN)
 	{
 		log_error("Username \"%s\" is too long (max: %d).\n", user, CONF_USER_MAXLEN);

--- a/src/conf.c
+++ b/src/conf.c
@@ -96,7 +96,10 @@ static int pusb_conf_parse_options(
 			return 0;
 		}
 		memset(xpath, 0x00, xpath_size);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 		snprintf(xpath, xpath_size, opt_list[i].name, opt_list[i].value, "");
+#pragma GCC diagnostic pop
 		pusb_conf_options_get_from(opts, xpath, doc);
 		xfree(xpath);
 	}
@@ -203,7 +206,7 @@ int pusb_conf_parse(
 	xmlDoc *doc = NULL;
 	char device_xpath[sizeof(CONF_USER_XPATH) + CONF_USER_MAXLEN + sizeof("device")];
 
-	log_debug("Parsing settings...\n", user, service);
+	log_debug("Parsing settings for user \"%s\", service \"%s\"...\n", user, service);
 	if (!pusb_conf_xpath_id_is_safe("Username", user) ||
 	    !pusb_conf_xpath_id_is_safe("Service", service))
 	{

--- a/src/log.h
+++ b/src/log.h
@@ -20,9 +20,9 @@
 #define log_debug(s, ...) __log_debug(__FILE__, __LINE__, s, ##__VA_ARGS__)
 #include "conf.h"
 
-void __log_debug(const char *file, int line, const char *fmt, ...);
-void log_error(const char *fmt, ...);
-void log_info(const char *fmt, ...);
+void __log_debug(const char *file, int line, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
+void log_error(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+void log_info(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 void pusb_log_init(t_pusb_options *opts);
 
 #endif /* !PUSB_LOG_H_ */

--- a/src/log.h
+++ b/src/log.h
@@ -20,9 +20,9 @@
 #define log_debug(s, ...) __log_debug(__FILE__, __LINE__, s, ##__VA_ARGS__)
 #include "conf.h"
 
-void __log_debug(const char *file, int line, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
-void log_error(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-void log_info(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+void __log_debug(const char *file, int line, const char *fmt, ...) __attribute__((format(printf, 3, 4))); /* DevSkim: ignore DS154189 - 'printf' here is a GCC attribute keyword, not a function call */
+void log_error(const char *fmt, ...) __attribute__((format(printf, 1, 2))); /* DevSkim: ignore DS154189 - 'printf' here is a GCC attribute keyword, not a function call */
+void log_info(const char *fmt, ...) __attribute__((format(printf, 1, 2))); /* DevSkim: ignore DS154189 - 'printf' here is a GCC attribute keyword, not a function call */
 void pusb_log_init(t_pusb_options *opts);
 
 #endif /* !PUSB_LOG_H_ */

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -122,9 +122,9 @@ int pusb_xpath_get_string(
 	}
 	if (!pusb_xpath_strip_string(value, (const char *)result_string, size))
 	{
+		log_debug("Result for %s (%s) is too long (max: %zu)\n", path, (const char *)result_string, size);
 		xmlFree(result_string);
 		xmlXPathFreeObject(result);
-		log_debug("Result for %s (%s) is too long (max: %zu)\n", path, (const char *)result_string, size);
 		return 0;
 	}
 	xmlFree(result_string);
@@ -166,13 +166,19 @@ int pusb_xpath_get_string_list(
 		if (!result_string || strcmp("", (char *)result_string) == 0)
 		{
 			log_debug("Empty value for %s\n", path);
+			xmlFree(result_string);
+			result_string = NULL;
 			continue;
 		}
 		if (!pusb_xpath_strip_string(values[currentResult], (char *)result_string, size))
 		{
 			log_debug("Result for %s (%s) is too long (max: %zu)\n", path, (const char *)result_string, size);
+			xmlFree(result_string);
+			result_string = NULL;
 			continue;
 		}
+		xmlFree(result_string);
+		result_string = NULL;
 	}
 
 	xmlFree(result_string);

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -124,7 +124,7 @@ int pusb_xpath_get_string(
 	{
 		xmlFree(result_string);
 		xmlXPathFreeObject(result);
-		log_debug("Result for %s (%s) is too long (max: %d)\n", path, (const char *)result_string, size);
+		log_debug("Result for %s (%s) is too long (max: %zu)\n", path, (const char *)result_string, size);
 		return 0;
 	}
 	xmlFree(result_string);
@@ -170,7 +170,7 @@ int pusb_xpath_get_string_list(
 		}
 		if (!pusb_xpath_strip_string(values[currentResult], (char *)result_string, size))
 		{
-			log_debug("Result for %s (%s) is too long (max: %d)\n", path, (const char *)result_string, size);
+			log_debug("Result for %s (%s) is too long (max: %zu)\n", path, (const char *)result_string, size);
 			continue;
 		}
 	}

--- a/tests/unit/c/mem_test.c
+++ b/tests/unit/c/mem_test.c
@@ -33,6 +33,13 @@ void __wrap_explicit_bzero(void *ptr, size_t len)
 		memset(ptr, 0, len);
 }
 
+/* Fortified variant called when _FORTIFY_SOURCE >= 1 and -O1+ is active */
+void __wrap___explicit_bzero_chk(void *ptr, size_t len, size_t destlen)
+{
+	(void)destlen;
+	__wrap_explicit_bzero(ptr, len);
+}
+
 /* ── xfree(NULL) must not crash ── */
 
 static void test_xfree_null_safe(void **state)


### PR DESCRIPTION
## Summary

Closes #366

Adds the full standard compiler and linker hardening flag set to the Makefile so that `pam_usb.so` (loaded into setuid PAM stacks) and `pamusb-check` are built with defence-in-depth protections active.

### Makefile changes

| Flag | Where | Purpose |
|---|---|---|
| `-O2` | CFLAGS | Required for `_FORTIFY_SOURCE` to activate at runtime; also standard production optimisation |
| `-fstack-protector-strong` | CFLAGS | Stack canary against stack buffer overflows |
| `-D_FORTIFY_SOURCE=2` | CFLAGS | glibc buffer-overflow detection for common string/memory functions |
| `-fstack-clash-protection` | CFLAGS | Prevents stack-clash attacks |
| `-fno-plt` | CFLAGS | Eliminates PLT stubs; all external calls go through GOT directly (minor perf + reduces writable GOT surface) |
| `-fzero-call-used-regs=used-gpr` | CFLAGS (conditional) | Zeroes caller-saved GPRs on function return; prevents register-based info leaks. Probed at `make` time — only added when the toolchain supports it (GCC ≥ 11). Silently omitted on older toolchains (e.g. Ubuntu 20.04 / Fedora 30 Docker images). |
| `-Wformat=2` | CFLAGS | Compile-time format-string security checking |
| `-fcf-protection=full` | CFLAGS (x86_64 only) | Intel CET IBT/SHSTK |
| `-O0 -U_FORTIFY_SOURCE` in DEBUG block | CFLAGS | Ensures `DEBUG=yes` overrides the `-O2` baseline, and suppresses the glibc "requires optimization" warning for `_FORTIFY_SOURCE=2` at `-O0` |
| `-Wl,-z,relro -Wl,-z,now` | HARDENING_LDFLAGS | Full RELRO |
| `-Wl,-z,noexecstack` | HARDENING_LDFLAGS | Explicit non-executable stack ELF note |
| `-pie` | pamusb-check link | ASLR for the binary |

### Why `-fPIC` + `-pie` rather than `-fPIE`

`$(OBJS)` is shared between the `.so` and `pamusb-check`. `-fPIE` objects cannot be linked into a shared library, so the common objects must remain `-fPIC`. Code compiled with `-fPIC` can be linked with `-pie` to produce a valid PIE executable.

### Source fixes surfaced by `-Wformat=2` + format attributes

Adding `__attribute__((format(printf,...)))` to the log function declarations in `src/log.h` caused GCC to check format strings at every call site, which found bugs and also triggered a second Gemini review that identified pre-existing memory safety issues:

- **`src/xpath.c` (get_string)** — Use-after-free: `xmlFree(result_string)` was called before the `log_debug()` that printed it. Fixed by reordering.
- **`src/xpath.c` (get_string_list)** — Memory leak: `result_string` was not freed on the too-long path or on successful loop iterations (post-loop `xmlFree` only freed the final pointer). Fixed by freeing and NULLing `result_string` in every loop code path; post-loop `xmlFree(NULL)` is a safe no-op.
- **`src/conf.c`** — `log_debug` with `user`/`service` ran before `pusb_conf_xpath_id_is_safe()` validation; moved to after validation to prevent NULL dereference.
- **`src/conf.c`** — `log_debug("Parsing settings...\n", user, service)` had no format specifiers for the two variadic args (silently discarded). Fixed by adding `%s` specifiers.
- **`src/xpath.c:127,173`** — `%d` used for `size_t`. Fixed to `%zu`.
- **`src/conf.c:99`** — Variable format string in XPath template expansion is intentional; suppressed with a targeted `#pragma GCC diagnostic` block.
- **`src/log.h`** — `format(printf,...)` attribute text flagged by DevSkim as banned function (false positive). Added `/* DevSkim: ignore DS154189 */` annotations.

### Test fix for `-O2` + `_FORTIFY_SOURCE=2`

With optimisation enabled, glibc rewrites `explicit_bzero()` calls to `__explicit_bzero_chk()` at compile time. The existing `--wrap=explicit_bzero` no longer intercepted the call, breaking `test_xfree_clears_memory`. Fixed by wrapping both symbols and adding a `__wrap___explicit_bzero_chk` mock that forwards to the existing counter.

### Verification

```
checksec --file=pam_usb.so
Full RELRO  Canary found  NX enabled  DSO  No RPATH  No RUNPATH  FORTIFY: Yes

checksec --file=pamusb-check
Full RELRO  Canary found  NX enabled  PIE enabled  No RPATH  No RUNPATH  FORTIFY: Yes
```

`make test` — all 174 tests pass (C unit tests + Python unit tests).

---

🤖 This PR was generated with the assistance of Claude Sonnet 4.6

I have read the rules