### PR TITLE
[Security] Fix NULL dereference in pusb_is_loginctl_local() when loginctl returns empty Remote field

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -249,6 +249,13 @@ char *pusb_get_tty_by_xorg_display(const char *display, const char *user)
 	return NULL;
 }
 
+static const char *pusb_loginctl_parse_output(char *buf)
+{
+	char *saveptr = NULL;
+	const char *val = strtok_r(buf, "\n", &saveptr);
+	return (val && *val != '\0') ? val : NULL;
+}
+
 char *pusb_get_tty_by_loginctl()
 {
 	char loginctl_cmd[BUFSIZ] = "LC_ALL=C; LOGINCTL_SESSION_ID=`/usr/bin/loginctl user-status | /usr/bin/grep -m 1  \"├─session-\" | /usr/bin/grep -o '[0-9]\\+'`; /usr/bin/loginctl show-session $LOGINCTL_SESSION_ID -p TTY | /usr/bin/awk -F= '{print $2}'";
@@ -264,8 +271,14 @@ char *pusb_get_tty_by_loginctl()
 	char *tty = NULL;
 	if (fgets(buf, BUFSIZ, fp) != NULL)
 	{
-		char *saveptr = NULL;
-		tty = strtok_r(buf, "\n", &saveptr);
+		tty = (char *)pusb_loginctl_parse_output(buf);
+		if (!tty)
+		{
+			log_debug("		'loginctl' returned empty TTY field, treating as unknown.\n");
+			if (pclose(fp))
+				log_debug("		Closing pipe for 'loginctl' failed, this is quite a wtf...\n");
+			return NULL;
+		}
 		log_debug("		Got tty: %s\n", tty);
 
 		if (pclose(fp))
@@ -273,7 +286,7 @@ char *pusb_get_tty_by_loginctl()
 			log_debug("		Closing pipe for 'loginctl' failed, this is quite a wtf...\n");
 		}
 
-		return tty ? xstrdup(tty) : NULL;
+		return xstrdup(tty);
 	}
 	else
 	{
@@ -299,11 +312,18 @@ int pusb_is_loginctl_local()
 		return 0;
 	}
 
-	char *is_remote = NULL;
+	const char *is_remote = NULL;
 	if (fgets(buf, BUFSIZ, fp) != NULL)
 	{
-		char *saveptr = NULL;
-		is_remote = strtok_r(buf, "\n", &saveptr);
+		is_remote = pusb_loginctl_parse_output(buf);
+		if (!is_remote)
+		{
+			log_debug("		loginctl returned empty Remote field, treating as unknown.\n");
+			if (pclose(fp))
+				log_debug("		Closing pipe for 'loginctl' failed, this is quite a wtf...\n");
+			return 0;
+		}
+
 		log_debug("		loginctl considers this session to be remote: %s\n", is_remote);
 
 		if (pclose(fp))
@@ -311,7 +331,7 @@ int pusb_is_loginctl_local()
 			log_debug("		Closing pipe for 'loginctl' failed, this is quite a wtf...\n");
 		}
 
-		if (strcmp(is_remote, "no") == 0) 
+		if (strcmp(is_remote, "no") == 0)
 		{
 			return 1;
 		}

--- a/src/local.c
+++ b/src/local.c
@@ -268,10 +268,10 @@ char *pusb_get_tty_by_loginctl()
 		return NULL;
 	}
 
-	char *tty = NULL;
+	const char *tty = NULL;
 	if (fgets(buf, BUFSIZ, fp) != NULL)
 	{
-		tty = (char *)pusb_loginctl_parse_output(buf);
+		tty = pusb_loginctl_parse_output(buf);
 		if (!tty)
 		{
 			log_debug("		'loginctl' returned empty TTY field, treating as unknown.\n");

--- a/tests/unit/c/local_test.c
+++ b/tests/unit/c/local_test.c
@@ -104,6 +104,38 @@ static void test_utmpx_field_starts_with_rejects_long_prefix(void **state)
 	assert_int_equal(0, pusb_utmpx_field_starts_with(field, sizeof(field), "pts/"));
 }
 
+static void test_loginctl_parse_output_newline_only(void **state)
+{
+	(void)state;
+	char buf[] = "\n";
+	assert_null(pusb_loginctl_parse_output(buf));
+}
+
+static void test_loginctl_parse_output_empty(void **state)
+{
+	(void)state;
+	char buf[] = "";
+	assert_null(pusb_loginctl_parse_output(buf));
+}
+
+static void test_loginctl_parse_output_valid_with_newline(void **state)
+{
+	(void)state;
+	char buf[] = "no\n";
+	const char *result = pusb_loginctl_parse_output(buf);
+	assert_non_null(result);
+	assert_string_equal("no", result);
+}
+
+static void test_loginctl_parse_output_valid_without_newline(void **state)
+{
+	(void)state;
+	char buf[] = "yes";
+	const char *result = pusb_loginctl_parse_output(buf);
+	assert_non_null(result);
+	assert_string_equal("yes", result);
+}
+
 static void test_local_login_denies_xrdp_session(void **state)
 {
 	(void)state;
@@ -177,6 +209,10 @@ int main(void)
 		cmocka_unit_test(test_utmpx_field_starts_with_pts_slave),
 		cmocka_unit_test(test_utmpx_field_starts_with_full_width_field),
 		cmocka_unit_test(test_utmpx_field_starts_with_rejects_long_prefix),
+		cmocka_unit_test(test_loginctl_parse_output_newline_only),
+		cmocka_unit_test(test_loginctl_parse_output_empty),
+		cmocka_unit_test(test_loginctl_parse_output_valid_with_newline),
+		cmocka_unit_test(test_loginctl_parse_output_valid_without_newline),
 		cmocka_unit_test(test_local_login_denies_xrdp_session),
 		cmocka_unit_test(test_local_login_display_env_null),
 		cmocka_unit_test(test_local_login_display_env_set),


### PR DESCRIPTION
## Summary

- `pusb_is_loginctl_local()` called `strcmp(is_remote, "no")` where `is_remote` could be NULL when `loginctl` outputs only a newline — `fgets` returns non-NULL but `strtok_r` returns NULL because the delimiter consumed the entire content, causing a SIGSEGV in the PAM module
- The same latent UB existed in `pusb_get_tty_by_loginctl()` where a NULL `tty` was passed to `log_debug` before the existing NULL-safe ternary guard
- Extracted `pusb_loginctl_parse_output()` to centralise and unit-test the parse-and-validate logic, then guarded both call sites to return a safe fallback (`0` / `NULL`) on empty output

## Technical approach

A shared static helper `pusb_loginctl_parse_output(char *buf)` wraps the `strtok_r` + empty-string check. This avoids duplicating the guard in both functions and makes the critical branch directly unit-testable without needing to mock `popen`. Both `pusb_is_loginctl_local()` and `pusb_get_tty_by_loginctl()` now early-return on NULL and close the pipe cleanly before doing so.

## Security benefit

Prevents a NULL dereference crash inside the PAM module triggered by a transiently uninitialised or missing loginctl session. Depending on PAM stack configuration this crash can affect all concurrent users (e.g. `sudo`, `login`) until the process is restarted — effectively a local denial of service. The fix ensures the unknown/empty case is treated as "indeterminate" and falls through to the next local-check method rather than crashing.

## Test plan

- [x] 4 new unit tests for `pusb_loginctl_parse_output()`: newline-only → NULL, empty → NULL, `"no\n"` → `"no"`, `"yes"` → `"yes"`
- [x] `make test` — all tests pass (17/17 in local_test, full suite green)
- [x] `tests/can-actually-be-used/run-tests.sh` — must be run manually on real hardware / custom runner

Closes #387
Refs #55

🤖 This PR was generated with the assistance of Claude Sonnet 4.6

I have read the rules