### PR TITLE
[Security] Fix integer overflow UB in pusb_xpath_get_time() and pusb_xpath_get_int()

### DIFF
--- a/src/xpath.c
+++ b/src/xpath.c
@@ -276,6 +276,7 @@ int pusb_xpath_get_time(xmlDocPtr doc, const char *path, time_t *value)
 	char *last;
 	char *endptr;
 	int coef;
+	int errsv;
 	long numeric;
 
 	if (!pusb_xpath_get_string(doc, path, ret, sizeof(ret)))
@@ -315,7 +316,9 @@ int pusb_xpath_get_time(xmlDocPtr doc, const char *path, time_t *value)
 	numeric = strtol(ret, &endptr, 10);
 	if (endptr == ret || *endptr != '\0' || errno != 0 || numeric < 0)
 	{
+		errsv = errno;
 		log_debug("Invalid or out-of-range time value: %s\n", ret);
+		errno = errsv;
 		return 0;
 	}
 	if (coef > 0 && numeric > LONG_MAX / coef)
@@ -357,6 +360,7 @@ int pusb_xpath_get_int(xmlDocPtr doc, const char *path, int *value)
 {
 	char ret[64];
 	char *endptr;
+	int errsv;
 	long numeric;
 
 	if (!pusb_xpath_get_string(doc, path, ret, sizeof(ret)))
@@ -368,7 +372,9 @@ int pusb_xpath_get_int(xmlDocPtr doc, const char *path, int *value)
 	numeric = strtol(ret, &endptr, 10);
 	if (endptr == ret || *endptr != '\0' || errno != 0 || numeric < INT_MIN || numeric > INT_MAX)
 	{
+		errsv = errno;
 		log_debug("Invalid or out-of-range int value: %s\n", ret);
+		errno = errsv;
 		return 0;
 	}
 	*value = (int)numeric;

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -326,7 +326,7 @@ int pusb_xpath_get_time(xmlDocPtr doc, const char *path, time_t *value)
 		log_debug("Time value overflow: %ld * %d\n", numeric, coef);
 		return 0;
 	}
-	*value = (time_t)numeric * coef;
+	*value = (time_t)(numeric * coef);
 
 	return 1;
 }

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -18,6 +18,9 @@
 #define _GNU_SOURCE
 #include <libxml/xpath.h>
 #include <ctype.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
 #include <string.h>
 #include "mem.h"
 #include "xpath.h"
@@ -271,7 +274,9 @@ int pusb_xpath_get_time(xmlDocPtr doc, const char *path, time_t *value)
 {
 	char ret[64];
 	char *last;
+	char *endptr;
 	int coef;
+	long numeric;
 
 	if (!pusb_xpath_get_string(doc, path, ret, sizeof(ret)))
 	{
@@ -306,7 +311,19 @@ int pusb_xpath_get_time(xmlDocPtr doc, const char *path, time_t *value)
 		*last = '\0';
 	}
 
-	*value = (time_t)atoi(ret) * coef;
+	errno = 0;
+	numeric = strtol(ret, &endptr, 10);
+	if (endptr == ret || *endptr != '\0' || errno != 0 || numeric < 0)
+	{
+		log_debug("Invalid or out-of-range time value: %s\n", ret);
+		return 0;
+	}
+	if (coef > 0 && numeric > LONG_MAX / coef)
+	{
+		log_debug("Time value overflow: %ld * %d\n", numeric, coef);
+		return 0;
+	}
+	*value = (time_t)numeric * coef;
 
 	return 1;
 }
@@ -339,13 +356,22 @@ int pusb_xpath_get_time_from(
 int pusb_xpath_get_int(xmlDocPtr doc, const char *path, int *value)
 {
 	char ret[64];
+	char *endptr;
+	long numeric;
 
 	if (!pusb_xpath_get_string(doc, path, ret, sizeof(ret)))
 	{
 		return 0;
 	}
 
-	*value = atoi(ret);
+	errno = 0;
+	numeric = strtol(ret, &endptr, 10);
+	if (endptr == ret || *endptr != '\0' || errno != 0 || numeric < INT_MIN || numeric > INT_MAX)
+	{
+		log_debug("Invalid or out-of-range int value: %s\n", ret);
+		return 0;
+	}
+	*value = (int)numeric;
 	return 1;
 }
 

--- a/tests/unit/c/xpath_test.c
+++ b/tests/unit/c/xpath_test.c
@@ -112,6 +112,48 @@ static void test_time_invalid_suffix(void **state)
 	xmlFreeDoc(doc);
 }
 
+static void test_time_negative(void **state)
+{
+	(void)state;
+	xmlDocPtr doc = make_doc("<r><v>-5s</v></r>");
+	time_t val = 999;
+	assert_int_equal(0, pusb_xpath_get_time(doc, "//r/v", &val));
+	assert_true(val == 999);
+	xmlFreeDoc(doc);
+}
+
+static void test_time_overflow(void **state)
+{
+	(void)state;
+	xmlDocPtr doc = make_doc("<r><v>9999999999999999999d</v></r>");
+	time_t val = 999;
+	assert_int_equal(0, pusb_xpath_get_time(doc, "//r/v", &val));
+	assert_true(val == 999);
+	xmlFreeDoc(doc);
+}
+
+static void test_time_overflow_via_multiplication(void **state)
+{
+	(void)state;
+	/* 200000000000000 * 86400 > LONG_MAX; fits strtol cleanly, only the
+	   multiplication overflow guard catches it */
+	xmlDocPtr doc = make_doc("<r><v>200000000000000d</v></r>");
+	time_t val = 999;
+	assert_int_equal(0, pusb_xpath_get_time(doc, "//r/v", &val));
+	assert_true(val == 999);
+	xmlFreeDoc(doc);
+}
+
+static void test_time_empty_numeric_part(void **state)
+{
+	(void)state;
+	xmlDocPtr doc = make_doc("<r><v>d</v></r>");
+	time_t val = 999;
+	assert_int_equal(0, pusb_xpath_get_time(doc, "//r/v", &val));
+	assert_true(val == 999);
+	xmlFreeDoc(doc);
+}
+
 /* ── pusb_xpath_get_int ── */
 
 static void test_int_value(void **state)
@@ -131,6 +173,36 @@ static void test_int_zero(void **state)
 	int val = 99;
 	assert_int_equal(1, pusb_xpath_get_int(doc, "//r/v", &val));
 	assert_int_equal(0, val);
+	xmlFreeDoc(doc);
+}
+
+static void test_int_overflow(void **state)
+{
+	(void)state;
+	xmlDocPtr doc = make_doc("<r><v>9999999999</v></r>");
+	int val = 42;
+	assert_int_equal(0, pusb_xpath_get_int(doc, "//r/v", &val));
+	assert_int_equal(42, val);
+	xmlFreeDoc(doc);
+}
+
+static void test_int_underflow(void **state)
+{
+	(void)state;
+	xmlDocPtr doc = make_doc("<r><v>-9999999999</v></r>");
+	int val = 42;
+	assert_int_equal(0, pusb_xpath_get_int(doc, "//r/v", &val));
+	assert_int_equal(42, val);
+	xmlFreeDoc(doc);
+}
+
+static void test_int_invalid_chars(void **state)
+{
+	(void)state;
+	xmlDocPtr doc = make_doc("<r><v>42abc</v></r>");
+	int val = 42;
+	assert_int_equal(0, pusb_xpath_get_int(doc, "//r/v", &val));
+	assert_int_equal(42, val);
 	xmlFreeDoc(doc);
 }
 
@@ -257,8 +329,15 @@ int main(void)
 		cmocka_unit_test(test_time_hours),
 		cmocka_unit_test(test_time_days),
 		cmocka_unit_test(test_time_invalid_suffix),
+		cmocka_unit_test(test_time_negative),
+		cmocka_unit_test(test_time_overflow),
+		cmocka_unit_test(test_time_overflow_via_multiplication),
+		cmocka_unit_test(test_time_empty_numeric_part),
 		cmocka_unit_test(test_int_value),
 		cmocka_unit_test(test_int_zero),
+		cmocka_unit_test(test_int_overflow),
+		cmocka_unit_test(test_int_underflow),
+		cmocka_unit_test(test_int_invalid_chars),
 		cmocka_unit_test(test_string_value),
 		cmocka_unit_test(test_string_whitespace_stripped),
 		cmocka_unit_test(test_string_too_long),


### PR DESCRIPTION
## Summary

Fixes two compounding undefined-behaviour issues in `src/xpath.c` identified during Security Audit Round 6.

- `atoi()` has UB on overflow (non-standard glibc saturation behaviour)
- `pusb_xpath_get_time()`: `(time_t)atoi(ret) * coef` is a signed `int × int` multiplication; with `coef = 86400` (days) a config value of `"25000d"` overflows a 32-bit `int` on 32-bit targets

## Changes

**`src/xpath.c`**
- Added `<errno.h>`, `<limits.h>`, `<stdlib.h>`
- `pusb_xpath_get_time()`: replaced `atoi` with `strtol` + validation (endptr empty/junk, errno, negative time, explicit `LONG_MAX / coef` multiplication overflow guard)
- `pusb_xpath_get_int()`: replaced `atoi` with `strtol` + validation (endptr, errno, `INT_MIN`/`INT_MAX` range check before `long → int` cast)
- Variable declarations hoisted to top of each function (project C89 style)

**`tests/unit/c/xpath_test.c`**
- 7 new unit tests: `test_time_negative`, `test_time_overflow`, `test_time_overflow_via_multiplication`, `test_time_empty_numeric_part`, `test_int_overflow`, `test_int_underflow`, `test_int_invalid_chars`

## Why this approach

`strtol` is the standard replacement for `atoi` when overflow detection is needed — it sets `errno = ERANGE` on out-of-range values and exposes the end pointer for non-numeric input detection. The separate multiplication overflow guard (`numeric > LONG_MAX / coef`) is required because `strtol` only bounds the raw parsed value, not the result of scaling it by `coef`. This check is portable to both 32-bit and 64-bit targets.

## Test results

All 28 C unit tests and 58 Python unit tests pass (`make test`).

Refs #55
Closes #389

🤖 This PR was generated with the assistance of Claude Sonnet 4.6

I have read the rules