### PR TITLE
Prepare 0.9.2 release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,20 @@
+* 0.9.2
+  [Enhancement] Emit log_error when superuser device filtering removes all devices (#399)
+  [Security] Fixed GHSA-rmp6-wfrq-wrrc (xfree() heap memory not cleared before free) (#374)
+  [Security] Fixed GHSA-64g7-3jrm-4jc3 (O_NOFOLLOW missing in evdev open, symlink following) (#376)
+  [Security] Fixed GHSA-hxh6-9574-5vp6 (O_EXCL missing on pad temp file creation) (#380)
+  [Security] Fixed GHSA-4j8q-67fq-3xc3 (TOCTOU race in pad directory creation) (#381)
+  [Security] Harden pusb_conf_xpath_id_is_safe to allowlist approach (#383)
+  [Security] Fixed GHSA-qr83-mf3h-fvqr (getenv() used in PAM context, env variable injection) (#384)
+  [Security] Fixed GHSA-96vv-r4wc-28c2 (XXE in xmlReadFile via default parser flags) (#385)
+  [Security] Add compiler and linker hardening flags (#386)
+  [Security] Fixed GHSA-7j6h-wfc2-mg5q (NULL dereference crash in pusb_is_loginctl_local) (#393)
+  [Security] Fixed GHSA-h28h-9hc3-v595 (infinite loop DoS in process-tree walk) (#394)
+  [Security] Fixed GHSA-rfcg-6wgv-77hw (integer overflow UB in xpath time/int parsing) (#395)
+  [Reliability] Fixed GHSA-vw5x-vxgv-fgxm (BUFSIZ truncation in pusb_get_process_envvar) (#396)
+  [Security] Fixed GHSA-xgfj-3wm2-gvx8 (fopen without O_CLOEXEC in process.c) (#397)
+  [Security] Fixed GHSA-chgp-j28w-mx9q (per-device config options silently never applied) (#398)
+
 * 0.9.1
   [Bugfix] Restore debug output suppressed before config parsing; fix XRDP detection log message (#355)
   [Security] Fixed GHSA-qg76-57wq-mpv6 (thread-unsafe static pointer in log.c) (#355)

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,7 +4,7 @@
   [Security] Fixed GHSA-64g7-3jrm-4jc3 (O_NOFOLLOW missing in evdev open, symlink following) (#376)
   [Security] Fixed GHSA-hxh6-9574-5vp6 (O_EXCL missing on pad temp file creation) (#380)
   [Security] Fixed GHSA-4j8q-67fq-3xc3 (TOCTOU race in pad directory creation) (#381)
-  [Security] Harden pusb_conf_xpath_id_is_safe to allowlist approach (#383)
+  [Security] Harden pusb_conf_xpath_id_is_safe: extend blocklist to reject double-quote and DEL (#383)
   [Security] Fixed GHSA-qr83-mf3h-fvqr (getenv() used in PAM context, env variable injection) (#384)
   [Security] Fixed GHSA-96vv-r4wc-28c2 (XXE in xmlReadFile via default parser flags) (#385)
   [Security] Add compiler and linker hardening flags (#386)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ At every point in time only the most recent release is supported.
 
 | Version | Supported          |
 |---------| ------------------ |
-| 0.9.1   | ✅                 |
-| < 0.9.1 | ❌                 |
+| 0.9.2   | ✅                 |
+| < 0.9.2 | ❌                 |
 
 ## Reporting a Vulnerability
 
@@ -29,4 +29,4 @@ Once a vulnerability has been reported via email and coordinated with the mainta
 
 There are multiple published security advisories for these versions.
 
-If you're running anything except 0.9.1 please update immediately!
+If you're running anything except 0.9.2 please update immediately!

--- a/arch_linux/PKGBUILD_stable
+++ b/arch_linux/PKGBUILD_stable
@@ -2,7 +2,7 @@
 # Contributor: Pekka Helenius <fincer89 [at] hotmail [dot] com>
 
 pkgname=pam_usb
-pkgver=0.9.1
+pkgver=0.9.2
 pkgrel=1
 pkgdesc='Hardware authentication for Linux using ordinary flash media (USB & Card based).'
 arch=($CARCH)
@@ -13,7 +13,7 @@ options=(!emptydirs)
 backup=("etc/security/pam_usb.conf")
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/$pkgver.tar.gz"
         "pamusb-agent.service")
-sha256sums=('e6d49c1a8b01af165c7c98ead9dc28020e8da138cb9c7e0906350477af5ae531'
+sha256sums=('SKIP'
             'f5875f0669b2638f36885c305d719072798b5097b15e6c94a8a852bb896bfc5c')
 
 build() {

--- a/arch_linux/PKGBUILD_stable
+++ b/arch_linux/PKGBUILD_stable
@@ -13,7 +13,7 @@ options=(!emptydirs)
 backup=("etc/security/pam_usb.conf")
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/$pkgver.tar.gz"
         "pamusb-agent.service")
-sha256sums=('SKIP'
+sha256sums=('6ddd263e22dbf0c1b7321bcd257b63b1926e1e4ff2bdc07038d54efabe5ff574'
             'f5875f0669b2638f36885c305d719072798b5097b15e6c94a8a852bb896bfc5c')
 
 build() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,23 @@
+libpam-usb (0.9.2) unstable; urgency=high
+
+  * [Enhancement] Emit log_error when superuser device filtering removes all devices (#399)
+  * [Security] Fixed GHSA-rmp6-wfrq-wrrc (xfree() heap memory not cleared before free) (#374)
+  * [Security] Fixed GHSA-64g7-3jrm-4jc3 (O_NOFOLLOW missing in evdev open, symlink following) (#376)
+  * [Security] Fixed GHSA-hxh6-9574-5vp6 (O_EXCL missing on pad temp file creation) (#380)
+  * [Security] Fixed GHSA-4j8q-67fq-3xc3 (TOCTOU race in pad directory creation) (#381)
+  * [Security] Harden pusb_conf_xpath_id_is_safe to allowlist approach (#383)
+  * [Security] Fixed GHSA-qr83-mf3h-fvqr (getenv() used in PAM context, env variable injection) (#384)
+  * [Security] Fixed GHSA-96vv-r4wc-28c2 (XXE in xmlReadFile via default parser flags) (#385)
+  * [Security] Add compiler and linker hardening flags (#386)
+  * [Security] Fixed GHSA-7j6h-wfc2-mg5q (NULL dereference crash in pusb_is_loginctl_local) (#393)
+  * [Security] Fixed GHSA-h28h-9hc3-v595 (infinite loop DoS in process-tree walk) (#394)
+  * [Security] Fixed GHSA-rfcg-6wgv-77hw (integer overflow UB in xpath time/int parsing) (#395)
+  * [Reliability] Fixed GHSA-vw5x-vxgv-fgxm (BUFSIZ truncation in pusb_get_process_envvar) (#396)
+  * [Security] Fixed GHSA-xgfj-3wm2-gvx8 (fopen without O_CLOEXEC in process.c) (#397)
+  * [Security] Fixed GHSA-chgp-j28w-mx9q (per-device config options silently never applied) (#398)
+
+ -- Tobias Bäumer <tobiasbaeumer@gmail.com>  Sat, 23 May 2026 00:00:00 +0200
+
 libpam-usb (0.9.1) unstable; urgency=high
 
   * [Bugfix] Restore debug output suppressed before config parsing; fix XRDP detection log message (#355)

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,7 +5,7 @@ libpam-usb (0.9.2) unstable; urgency=high
   * [Security] Fixed GHSA-64g7-3jrm-4jc3 (O_NOFOLLOW missing in evdev open, symlink following) (#376)
   * [Security] Fixed GHSA-hxh6-9574-5vp6 (O_EXCL missing on pad temp file creation) (#380)
   * [Security] Fixed GHSA-4j8q-67fq-3xc3 (TOCTOU race in pad directory creation) (#381)
-  * [Security] Harden pusb_conf_xpath_id_is_safe to allowlist approach (#383)
+  * [Security] Harden pusb_conf_xpath_id_is_safe: extend blocklist to reject double-quote and DEL (#383)
   * [Security] Fixed GHSA-qr83-mf3h-fvqr (getenv() used in PAM context, env variable injection) (#384)
   * [Security] Fixed GHSA-96vv-r4wc-28c2 (XXE in xmlReadFile via default parser flags) (#385)
   * [Security] Add compiler and linker hardening flags (#386)

--- a/doc/CONFIGURATION
+++ b/doc/CONFIGURATION
@@ -61,10 +61,8 @@ The syntax is the following:
 > **Option precedence:** Options defined in later scopes override those in earlier scopes.
 > The order is: `<defaults>` → `<users>` → `<services>`.
 > A user-level option overrides the global default; a service-level option overrides both.
->
-> **Note:** `<option>` elements placed inside a `<device>` block are currently not applied
-> at runtime and will be ignored with a warning message. This is a known limitation — use `<defaults>`,
-> `<users>`, or `<services>` to configure options instead.
+> Device-level `<option>` elements (inside a `<device>` block) are supported from v0.9.2 and
+> apply when that specific device is used for authentication.
 
 ### Example:
 
@@ -343,7 +341,7 @@ The `superuser` option can be applied to any service name that appears in your P
 
 ### Log output
 
-If all of a user's devices are excluded by the superuser filter, pam_usb emits an error visible in the system log even without debug mode:
+If all of a user's devices are excluded by the superuser filter, pam_usb emits an error visible in the system log even without debug mode *(from v0.9.2)*:
 
 ```
 Service "sudo" for user "alex" requires a superuser-capable device but none of the registered devices have the superuser attribute.

--- a/doc/CONFIGURATION
+++ b/doc/CONFIGURATION
@@ -61,8 +61,10 @@ The syntax is the following:
 > **Option precedence:** Options defined in later scopes override those in earlier scopes.
 > The order is: `<defaults>` → `<users>` → `<services>`.
 > A user-level option overrides the global default; a service-level option overrides both.
-> Device-level `<option>` elements (inside a `<device>` block) are supported from v0.9.2 and
-> apply when that specific device is used for authentication.
+>
+> **Note:** `<option>` elements placed inside a `<device>` block are not applied
+> at runtime. From v0.9.2 an error is logged when they are found in the config.
+> Use `<defaults>`, `<users>`, or `<services>` to configure options instead.
 
 ### Example:
 

--- a/doc/SECURITY
+++ b/doc/SECURITY
@@ -209,9 +209,15 @@ You can apply the `superuser` option to any service name that appears in your PA
 
 ---
 
-### Debug output
+### Log output
 
-With `<option name="debug">true</option>`, the filtering is logged:
+If all of a user's devices are excluded by the superuser filter, pam_usb emits an error visible in the system log even without debug mode *(from v0.9.2)*:
+
+```
+Service "sudo" for user "alex" requires a superuser-capable device but none of the registered devices have the superuser attribute.
+```
+
+With `<option name="debug">true</option>`, the per-device filtering decisions are also logged:
 
 ```
 Service "sudo" requires superuser device. Filtering device list.

--- a/doc/SECURITY
+++ b/doc/SECURITY
@@ -8,7 +8,7 @@ Also I want to point it that this is barely audited. I've tried to raise funds f
 
 # Warning about XDMCP
 
-This warning has been **partially mitigated** in 0.9.1 but XDMCP + pam_usb is still not recommended. Read carefully.
+This warning has been **partially mitigated** since 0.9.1 but XDMCP + pam_usb is still not recommended. Read carefully.
 
 **What changed in 0.9.1 (GHSA-w38v-cw9r-x9p6):** The root cause of the original bypass was that the `PAM_RHOST` check was gated behind the `deny_remote` option. Display managers whitelisted with `deny_remote=false` (e.g. `gdm-password`, `lightdm`) also skipped the `PAM_RHOST` check entirely, so a remote XDMCP client was never identified as remote by pam_usb.
 

--- a/fedora/SPECS/pam_usb.spec
+++ b/fedora/SPECS/pam_usb.spec
@@ -1,7 +1,7 @@
 %define _topdir         /usr/local/src/pam_usb/fedora
 %define name            pam_usb 
 %define release         1
-%define version         0.9.1
+%define version         0.9.2
 %define buildroot       %{_topdir}/%{name}‑%{version}‑root
 
 BuildRoot: %{buildroot}
@@ -61,6 +61,23 @@ rm -rf %{buildroot}/usr/share/pam-configs
 %doc %attr(0644,root,root) /usr/share/doc/pam_usb/TROUBLESHOOTING
 
 %changelog
+
+* Sat May 23 2026 Tobias Bäumer <tobiasbaeumer@gmail.com> - 0.9.2
+- [Enhancement] Emit log_error when superuser device filtering removes all devices (#399)
+- [Security] Fixed GHSA-rmp6-wfrq-wrrc (xfree() heap memory not cleared before free) (#374)
+- [Security] Fixed GHSA-64g7-3jrm-4jc3 (O_NOFOLLOW missing in evdev open, symlink following) (#376)
+- [Security] Fixed GHSA-hxh6-9574-5vp6 (O_EXCL missing on pad temp file creation) (#380)
+- [Security] Fixed GHSA-4j8q-67fq-3xc3 (TOCTOU race in pad directory creation) (#381)
+- [Security] Harden pusb_conf_xpath_id_is_safe to allowlist approach (#383)
+- [Security] Fixed GHSA-qr83-mf3h-fvqr (getenv() used in PAM context, env variable injection) (#384)
+- [Security] Fixed GHSA-96vv-r4wc-28c2 (XXE in xmlReadFile via default parser flags) (#385)
+- [Security] Add compiler and linker hardening flags (#386)
+- [Security] Fixed GHSA-7j6h-wfc2-mg5q (NULL dereference crash in pusb_is_loginctl_local) (#393)
+- [Security] Fixed GHSA-h28h-9hc3-v595 (infinite loop DoS in process-tree walk) (#394)
+- [Security] Fixed GHSA-rfcg-6wgv-77hw (integer overflow UB in xpath time/int parsing) (#395)
+- [Reliability] Fixed GHSA-vw5x-vxgv-fgxm (BUFSIZ truncation in pusb_get_process_envvar) (#396)
+- [Security] Fixed GHSA-xgfj-3wm2-gvx8 (fopen without O_CLOEXEC in process.c) (#397)
+- [Security] Fixed GHSA-chgp-j28w-mx9q (per-device config options silently never applied) (#398)
 
 * Wed May 20 2026 Tobias Bäumer <tobiasbaeumer@gmail.com> - 0.9.1
 - [Bugfix] Restore debug output suppressed before config parsing; fix XRDP detection log message (#355)

--- a/fedora/SPECS/pam_usb.spec
+++ b/fedora/SPECS/pam_usb.spec
@@ -68,7 +68,7 @@ rm -rf %{buildroot}/usr/share/pam-configs
 - [Security] Fixed GHSA-64g7-3jrm-4jc3 (O_NOFOLLOW missing in evdev open, symlink following) (#376)
 - [Security] Fixed GHSA-hxh6-9574-5vp6 (O_EXCL missing on pad temp file creation) (#380)
 - [Security] Fixed GHSA-4j8q-67fq-3xc3 (TOCTOU race in pad directory creation) (#381)
-- [Security] Harden pusb_conf_xpath_id_is_safe to allowlist approach (#383)
+- [Security] Harden pusb_conf_xpath_id_is_safe: extend blocklist to reject double-quote and DEL (#383)
 - [Security] Fixed GHSA-qr83-mf3h-fvqr (getenv() used in PAM context, env variable injection) (#384)
 - [Security] Fixed GHSA-96vv-r4wc-28c2 (XXE in xmlReadFile via default parser flags) (#385)
 - [Security] Add compiler and linker hardening flags (#386)

--- a/src/version.h
+++ b/src/version.h
@@ -18,6 +18,6 @@
 #ifndef PUSB_VERSION_H_
 # define PUSB_VERSION_H_
 
-# define PUSB_VERSION "0.9.1"
+# define PUSB_VERSION "0.9.2"
 
 #endif /* !PUSB_VERSION_H_ */

--- a/tools/pamusb-conf
+++ b/tools/pamusb-conf
@@ -421,7 +421,7 @@ def resetPads():
 	sys.exit(0)
 
 def usage():
-	print('Version 0.9.1')
+	print('Version 0.9.2')
 	print('Usage: %s [--help] [--verbose] [--yes] [--config=path] [--reset-pads=username]' % os.path.basename(__file__))
 	print('                [[--add-user=name [--superuser]] | [--add-device=name [[--device=number] [--volume=number]]]]')
 	sys.exit(1)


### PR DESCRIPTION
## Summary

- Bumps version to 0.9.2 across all relevant files (`version.h`, `pamusb-conf`, changelogs, packaging)
- Updates `SECURITY.md` to list 0.9.2 as the supported version
- Adds `ChangeLog` / Debian / Fedora / Arch entries covering all 15 changes since 0.9.1
- Updates wiki docs via `make update-other-docs` (fixes per-device config caveat wording, adds v0.9.2 markers)
- All 12 draft GHSAs updated with `patched_versions = 0.9.2` (remain unpublished)
- Arch `PKGBUILD_stable` sha256sum computed via `git archive` — stable for repos without submodules or `.gitattributes` export rules

## Why this approach

Standard release prep commit: all version bumps and changelog entries are atomic in a single commit so the merge produces a clean, bisectable history. The docs update is a separate commit (required by `make update-other-docs`).

Closes #400

🤖 This PR was generated with the assistance of Claude Sonnet 4.6

I have read the rules