### PR TITLE
[Tooling] Add zst-sign Makefile target for Arch package signing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,6 +292,10 @@ rpm: clean builddir
 rpm-sign: build-fedora
 	rpm --addsign `ls -t .build/*.rpm | head -1`
 
+zst-sign: build-arch
+	@pkg=$$(ls -t .build/*.pkg.tar.zst 2>/dev/null | head -1); \
+	if [ -n "$$pkg" ]; then gpg --detach-sign "$$pkg"; else echo "No package found to sign"; exit 1; fi
+
 rpm-lint: build-fedora
 	rpmlint `ls -t .build/*.rpm | head -1`
 


### PR DESCRIPTION
## Summary

- Adds a `zst-sign` target to the Makefile for signing Arch Linux `.pkg.tar.zst` packages
- Uses `gpg --detach-sign` with the default GPG key, consistent with how `rpm-sign` uses the key configured in `~/.rpmmacros`
- Produces a `.pkg.tar.zst.sig` detached signature alongside the package in `.build/`, which `pacman -U` verifies automatically when the key is in the user's pacman keyring

## Why this approach

`deb-sign` and `rpm-sign` are post-build signing steps that operate on the artifact in `.build/` after the Docker build completes. The `zst-sign` target follows the exact same pattern — build via `build-arch`, then sign locally. Using `gpg --detach-sign` without `-u` mirrors the key-selection behaviour of `rpm --addsign` (both use the default configured key rather than requiring an explicit env var).

Closes #407

## Test plan

- [x] Built and signed locally: `make zst-sign` produced `.pkg.tar.zst.sig` in `.build/`
- [x] Verified signature: `gpg --verify .build/*.pkg.tar.zst.sig .build/*.pkg.tar.zst` confirmed good signature

🤖 This PR was generated with the assistance of Claude Sonnet 4.6

I have read the rules