### PR TITLE
Add multi-filesystem functional test coverage (ext4, exFAT)

### DIFF
--- a/.github/workflows/build-and-test-on-own-server.yml
+++ b/.github/workflows/build-and-test-on-own-server.yml
@@ -132,7 +132,7 @@ jobs:
         TEST_RUNNER_USER_NEW: ${{ secrets.TEST_RUNNER_USER_NEW }}
         TEST_RUNNER_PASS_NEW: ${{ secrets.TEST_RUNNER_PASS_2025 }}
         TEST_RUNNER_PORT_NEW: ${{ secrets.TEST_RUNNER_PORT_NEW }}
-      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "cd ~/pam_usb_$GITHUB_RUN_ID/tests/can-actually-be-used && ./run-tests.sh"
+      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -tt -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "cd ~/pam_usb_$GITHUB_RUN_ID/tests/can-actually-be-used && ./run-tests.sh"
     - name: cleanup - umount & remove image file, pads, mountpoint
       if: always()
       env:

--- a/.github/workflows/build-and-test-on-own-server.yml
+++ b/.github/workflows/build-and-test-on-own-server.yml
@@ -37,7 +37,7 @@ jobs:
         TEST_RUNNER_PASS_NEW: ${{ secrets.TEST_RUNNER_PASS_2025 }}
         TEST_RUNNER_PORT_NEW: ${{ secrets.TEST_RUNNER_PORT_NEW }}
       # NOTE: deps are installed directly on the remote host via SSH; keep in sync with .github/actions/install-build-deps/action.yml
-      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "sudo apt --yes install fdisk libudisks2-dev libxml2-dev python-is-python3 python3-dotenv libpam0g-dev devscripts debhelper dkms pkg-config gir1.2-glib-2.0 libglib2.0-dev libevdev-dev"
+      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "sudo apt --yes install fdisk libudisks2-dev libxml2-dev python-is-python3 python3-dotenv libpam0g-dev devscripts debhelper dkms pkg-config gir1.2-glib-2.0 libglib2.0-dev libevdev-dev exfatprogs"
     - name: git clone
       env:
         TEST_RUNNER_HOST_NEW: ${{ secrets.TEST_RUNNER_HOST_NEW }}
@@ -126,20 +126,6 @@ jobs:
         TEST_RUNNER_PASS_NEW: ${{ secrets.TEST_RUNNER_PASS_2025 }}
         TEST_RUNNER_PORT_NEW: ${{ secrets.TEST_RUNNER_PORT_NEW }}
       run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "cd ~/pam_usb_$GITHUB_RUN_ID/tests/can-actually-be-used && ./prepare-mounting.sh"
-    - name: create fake usb stick image
-      env:
-        TEST_RUNNER_HOST_NEW: ${{ secrets.TEST_RUNNER_HOST_NEW }}
-        TEST_RUNNER_USER_NEW: ${{ secrets.TEST_RUNNER_USER_NEW }}
-        TEST_RUNNER_PASS_NEW: ${{ secrets.TEST_RUNNER_PASS_2025 }}
-        TEST_RUNNER_PORT_NEW: ${{ secrets.TEST_RUNNER_PORT_NEW }}
-      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "cd ~/pam_usb_$GITHUB_RUN_ID/tests/can-actually-be-used && ./create-image.sh"
-    - name: Insert/partition/format/mount fake usb stick
-      env:
-        TEST_RUNNER_HOST_NEW: ${{ secrets.TEST_RUNNER_HOST_NEW }}
-        TEST_RUNNER_USER_NEW: ${{ secrets.TEST_RUNNER_USER_NEW }}
-        TEST_RUNNER_PASS_NEW: ${{ secrets.TEST_RUNNER_PASS_2025 }}
-        TEST_RUNNER_PORT_NEW: ${{ secrets.TEST_RUNNER_PORT_NEW }}
-      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "cd ~/pam_usb_$GITHUB_RUN_ID/tests/can-actually-be-used && ./mount-image.sh"
     - name: execute test cases
       env:
         TEST_RUNNER_HOST_NEW: ${{ secrets.TEST_RUNNER_HOST_NEW }}

--- a/.github/workflows/build-and-test-on-own-server.yml
+++ b/.github/workflows/build-and-test-on-own-server.yml
@@ -132,7 +132,7 @@ jobs:
         TEST_RUNNER_USER_NEW: ${{ secrets.TEST_RUNNER_USER_NEW }}
         TEST_RUNNER_PASS_NEW: ${{ secrets.TEST_RUNNER_PASS_2025 }}
         TEST_RUNNER_PORT_NEW: ${{ secrets.TEST_RUNNER_PORT_NEW }}
-      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -tt -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "cd ~/pam_usb_$GITHUB_RUN_ID/tests/can-actually-be-used && ./run-tests.sh"
+      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "cd ~/pam_usb_$GITHUB_RUN_ID/tests/can-actually-be-used && ./run-tests.sh"
     - name: cleanup - umount & remove image file, pads, mountpoint
       if: always()
       env:

--- a/tests/can-actually-be-used/do-mount.sh
+++ b/tests/can-actually-be-used/do-mount.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/bash
+
+# Usage: do-mount.sh <fs_type> <device>
+# Mounts <device> to /tmp/fakestick with options appropriate for <fs_type>.
+
+set -e
+
+FS_TYPE=$1
+DEVICE=$2
+
+case "$FS_TYPE" in
+    vfat|exfat)
+        sudo mount -t "$FS_TYPE" "$DEVICE" /tmp/fakestick -o rw,umask=0000 ;;
+    ext4)
+        sudo mount -t ext4 "$DEVICE" /tmp/fakestick -o rw
+        sudo chmod 777 /tmp/fakestick ;;
+    *)
+        echo "Error: unsupported filesystem type '$FS_TYPE'" >&2
+        exit 1 ;;
+esac

--- a/tests/can-actually-be-used/mount-image.sh
+++ b/tests/can-actually-be-used/mount-image.sh
@@ -2,24 +2,43 @@
 
 set -e
 
-# Format both images offline — sfdisk and mkfs.vfat work directly on raw files
-echo "Info: preparing virtual_usb.img..."
+PUSB_FS_TYPE=${PUSB_FS_TYPE:-vfat}
+
+# Partition tables offline — sfdisk works on raw image files for all FS types
+echo "Info: preparing partition tables..."
 echo 'type=83' | sfdisk virtual_usb.img
-mkfs.vfat --offset 2048 virtual_usb.img
-
-echo "Info: preparing virtual_usb_alt.img for second device..."
 echo 'type=83' | sfdisk virtual_usb_alt.img
-mkfs.vfat --offset 2048 virtual_usb_alt.img
 
-# Load module with primary image
+# Format primary image online
+echo "Info: formatting virtual_usb.img as $PUSB_FS_TYPE..."
 sudo modprobe g_mass_storage file=./virtual_usb.img stall=0 removable=y iSerialNumber=1234567890 iProduct=FirstStick
-echo "Info: sleeping 5s to ensure kernel picks up our new device..."
-sleep 5
+sudo udevadm settle
+PRIMARY_DEV=$(lsblk | grep disk | grep 16M | awk '{ print $1 }')
+sudo mkfs.$PUSB_FS_TYPE "/dev/${PRIMARY_DEV}1"
+sudo modprobe -r g_mass_storage
+sudo udevadm settle
 
-# Determine device id and mount it
+# Format alt image online
+echo "Info: formatting virtual_usb_alt.img as $PUSB_FS_TYPE..."
+sudo modprobe g_mass_storage file=./virtual_usb_alt.img stall=0 removable=y iSerialNumber=1234567891 iProduct=SecondStick
+sudo udevadm settle
+ALT_DEV=$(lsblk | grep disk | grep 16M | awk '{ print $1 }')
+sudo mkfs.$PUSB_FS_TYPE "/dev/${ALT_DEV}1"
+sudo modprobe -r g_mass_storage
+sudo udevadm settle
+
+# Load primary image and mount it
+sudo modprobe g_mass_storage file=./virtual_usb.img stall=0 removable=y iSerialNumber=1234567890 iProduct=FirstStick
+sudo udevadm settle
+
 CREATED_DEVICE=$(lsblk | grep disk | grep 16M | awk '{ print $1 }')
 echo "Info: fake device registered as /dev/$CREATED_DEVICE"
 
-# Create mountpoint and mount fake stick
 mkdir -p /tmp/fakestick
-sudo mount -t vfat "/dev/"$CREATED_DEVICE"1" /tmp/fakestick -o rw,umask=0000
+case "$PUSB_FS_TYPE" in
+    vfat|exfat)
+        sudo mount -t "$PUSB_FS_TYPE" "/dev/${CREATED_DEVICE}1" /tmp/fakestick -o rw,umask=0000 ;;
+    ext4)
+        sudo mount -t ext4 "/dev/${CREATED_DEVICE}1" /tmp/fakestick -o rw
+        sudo chmod 777 /tmp/fakestick ;;
+esac

--- a/tests/can-actually-be-used/mount-image.sh
+++ b/tests/can-actually-be-used/mount-image.sh
@@ -13,8 +13,9 @@ echo 'type=83' | sfdisk virtual_usb_alt.img
 echo "Info: formatting virtual_usb.img as $PUSB_FS_TYPE..."
 sudo modprobe g_mass_storage file=./virtual_usb.img stall=0 removable=y iSerialNumber=1234567890 iProduct=FirstStick
 sudo udevadm settle
-PRIMARY_DEV=$(lsblk | grep disk | grep 16M | awk '{ print $1 }')
+PRIMARY_DEV=$(lsblk -dno NAME,SIZE | grep '16M' | awk '{ print $1 }' | head -n 1)
 sudo mkfs.$PUSB_FS_TYPE "/dev/${PRIMARY_DEV}1"
+sync
 sudo modprobe -r g_mass_storage
 sudo udevadm settle
 
@@ -22,8 +23,9 @@ sudo udevadm settle
 echo "Info: formatting virtual_usb_alt.img as $PUSB_FS_TYPE..."
 sudo modprobe g_mass_storage file=./virtual_usb_alt.img stall=0 removable=y iSerialNumber=1234567891 iProduct=SecondStick
 sudo udevadm settle
-ALT_DEV=$(lsblk | grep disk | grep 16M | awk '{ print $1 }')
+ALT_DEV=$(lsblk -dno NAME,SIZE | grep '16M' | awk '{ print $1 }' | head -n 1)
 sudo mkfs.$PUSB_FS_TYPE "/dev/${ALT_DEV}1"
+sync
 sudo modprobe -r g_mass_storage
 sudo udevadm settle
 
@@ -31,14 +33,8 @@ sudo udevadm settle
 sudo modprobe g_mass_storage file=./virtual_usb.img stall=0 removable=y iSerialNumber=1234567890 iProduct=FirstStick
 sudo udevadm settle
 
-CREATED_DEVICE=$(lsblk | grep disk | grep 16M | awk '{ print $1 }')
+CREATED_DEVICE=$(lsblk -dno NAME,SIZE | grep '16M' | awk '{ print $1 }' | head -n 1)
 echo "Info: fake device registered as /dev/$CREATED_DEVICE"
 
 mkdir -p /tmp/fakestick
-case "$PUSB_FS_TYPE" in
-    vfat|exfat)
-        sudo mount -t "$PUSB_FS_TYPE" "/dev/${CREATED_DEVICE}1" /tmp/fakestick -o rw,umask=0000 ;;
-    ext4)
-        sudo mount -t ext4 "/dev/${CREATED_DEVICE}1" /tmp/fakestick -o rw
-        sudo chmod 777 /tmp/fakestick ;;
-esac
+./do-mount.sh "$PUSB_FS_TYPE" "/dev/${CREATED_DEVICE}1"

--- a/tests/can-actually-be-used/mount-image.sh
+++ b/tests/can-actually-be-used/mount-image.sh
@@ -21,8 +21,13 @@ for i in $(seq 1 10); do
     sleep 1
 done
 [ -z "$PRIMARY_DEV" ] && { echo "Error: no new block device appeared after loading g_mass_storage" >&2; exit 1; }
-sudo mkfs.$PUSB_FS_TYPE "/dev/${PRIMARY_DEV}1"
+case "$PUSB_FS_TYPE" in
+    ext4)  sudo mkfs.ext4 -F "/dev/${PRIMARY_DEV}1" ;;
+    exfat) sudo mkfs.exfat -f "/dev/${PRIMARY_DEV}1" ;;
+    *)     sudo mkfs.$PUSB_FS_TYPE "/dev/${PRIMARY_DEV}1" ;;
+esac
 sync
+sudo udevadm settle
 sudo modprobe -r g_mass_storage
 sudo udevadm settle
 
@@ -38,8 +43,13 @@ for i in $(seq 1 10); do
     sleep 1
 done
 [ -z "$ALT_DEV" ] && { echo "Error: no new block device appeared after loading g_mass_storage (alt)" >&2; exit 1; }
-sudo mkfs.$PUSB_FS_TYPE "/dev/${ALT_DEV}1"
+case "$PUSB_FS_TYPE" in
+    ext4)  sudo mkfs.ext4 -F "/dev/${ALT_DEV}1" ;;
+    exfat) sudo mkfs.exfat -f "/dev/${ALT_DEV}1" ;;
+    *)     sudo mkfs.$PUSB_FS_TYPE "/dev/${ALT_DEV}1" ;;
+esac
 sync
+sudo udevadm settle
 sudo modprobe -r g_mass_storage
 sudo udevadm settle
 

--- a/tests/can-actually-be-used/mount-image.sh
+++ b/tests/can-actually-be-used/mount-image.sh
@@ -11,9 +11,12 @@ echo 'type=83' | sfdisk virtual_usb_alt.img
 
 # Format primary image online
 echo "Info: formatting virtual_usb.img as $PUSB_FS_TYPE..."
+DEVS_BEFORE=$(lsblk -dno NAME | sort)
 sudo modprobe g_mass_storage file=./virtual_usb.img stall=0 removable=y iSerialNumber=1234567890 iProduct=FirstStick
 sudo udevadm settle
-PRIMARY_DEV=$(lsblk -dno NAME,SIZE | grep '16M' | awk '{ print $1 }' | head -n 1)
+DEVS_AFTER=$(lsblk -dno NAME | sort)
+PRIMARY_DEV=$(comm -13 <(echo "$DEVS_BEFORE") <(echo "$DEVS_AFTER") | grep -v '^loop' | head -1)
+[ -z "$PRIMARY_DEV" ] && { echo "Error: no new block device appeared after loading g_mass_storage" >&2; exit 1; }
 sudo mkfs.$PUSB_FS_TYPE "/dev/${PRIMARY_DEV}1"
 sync
 sudo modprobe -r g_mass_storage
@@ -21,19 +24,24 @@ sudo udevadm settle
 
 # Format alt image online
 echo "Info: formatting virtual_usb_alt.img as $PUSB_FS_TYPE..."
+DEVS_BEFORE=$(lsblk -dno NAME | sort)
 sudo modprobe g_mass_storage file=./virtual_usb_alt.img stall=0 removable=y iSerialNumber=1234567891 iProduct=SecondStick
 sudo udevadm settle
-ALT_DEV=$(lsblk -dno NAME,SIZE | grep '16M' | awk '{ print $1 }' | head -n 1)
+DEVS_AFTER=$(lsblk -dno NAME | sort)
+ALT_DEV=$(comm -13 <(echo "$DEVS_BEFORE") <(echo "$DEVS_AFTER") | grep -v '^loop' | head -1)
+[ -z "$ALT_DEV" ] && { echo "Error: no new block device appeared after loading g_mass_storage (alt)" >&2; exit 1; }
 sudo mkfs.$PUSB_FS_TYPE "/dev/${ALT_DEV}1"
 sync
 sudo modprobe -r g_mass_storage
 sudo udevadm settle
 
 # Load primary image and mount it
+DEVS_BEFORE=$(lsblk -dno NAME | sort)
 sudo modprobe g_mass_storage file=./virtual_usb.img stall=0 removable=y iSerialNumber=1234567890 iProduct=FirstStick
 sudo udevadm settle
-
-CREATED_DEVICE=$(lsblk -dno NAME,SIZE | grep '16M' | awk '{ print $1 }' | head -n 1)
+DEVS_AFTER=$(lsblk -dno NAME | sort)
+CREATED_DEVICE=$(comm -13 <(echo "$DEVS_BEFORE") <(echo "$DEVS_AFTER") | grep -v '^loop' | head -1)
+[ -z "$CREATED_DEVICE" ] && { echo "Error: no new block device appeared after loading g_mass_storage" >&2; exit 1; }
 echo "Info: fake device registered as /dev/$CREATED_DEVICE"
 
 mkdir -p /tmp/fakestick

--- a/tests/can-actually-be-used/mount-image.sh
+++ b/tests/can-actually-be-used/mount-image.sh
@@ -14,8 +14,12 @@ echo "Info: formatting virtual_usb.img as $PUSB_FS_TYPE..."
 DEVS_BEFORE=$(lsblk -dno NAME | sort)
 sudo modprobe g_mass_storage file=./virtual_usb.img stall=0 removable=y iSerialNumber=1234567890 iProduct=FirstStick
 sudo udevadm settle
-DEVS_AFTER=$(lsblk -dno NAME | sort)
-PRIMARY_DEV=$(comm -13 <(echo "$DEVS_BEFORE") <(echo "$DEVS_AFTER") | grep -v '^loop' | head -1)
+PRIMARY_DEV=""
+for i in $(seq 1 10); do
+    PRIMARY_DEV=$(comm -13 <(echo "$DEVS_BEFORE") <(lsblk -dno NAME | sort) | grep -v '^loop' | head -1)
+    [ -n "$PRIMARY_DEV" ] && break
+    sleep 1
+done
 [ -z "$PRIMARY_DEV" ] && { echo "Error: no new block device appeared after loading g_mass_storage" >&2; exit 1; }
 sudo mkfs.$PUSB_FS_TYPE "/dev/${PRIMARY_DEV}1"
 sync
@@ -27,8 +31,12 @@ echo "Info: formatting virtual_usb_alt.img as $PUSB_FS_TYPE..."
 DEVS_BEFORE=$(lsblk -dno NAME | sort)
 sudo modprobe g_mass_storage file=./virtual_usb_alt.img stall=0 removable=y iSerialNumber=1234567891 iProduct=SecondStick
 sudo udevadm settle
-DEVS_AFTER=$(lsblk -dno NAME | sort)
-ALT_DEV=$(comm -13 <(echo "$DEVS_BEFORE") <(echo "$DEVS_AFTER") | grep -v '^loop' | head -1)
+ALT_DEV=""
+for i in $(seq 1 10); do
+    ALT_DEV=$(comm -13 <(echo "$DEVS_BEFORE") <(lsblk -dno NAME | sort) | grep -v '^loop' | head -1)
+    [ -n "$ALT_DEV" ] && break
+    sleep 1
+done
 [ -z "$ALT_DEV" ] && { echo "Error: no new block device appeared after loading g_mass_storage (alt)" >&2; exit 1; }
 sudo mkfs.$PUSB_FS_TYPE "/dev/${ALT_DEV}1"
 sync
@@ -39,8 +47,12 @@ sudo udevadm settle
 DEVS_BEFORE=$(lsblk -dno NAME | sort)
 sudo modprobe g_mass_storage file=./virtual_usb.img stall=0 removable=y iSerialNumber=1234567890 iProduct=FirstStick
 sudo udevadm settle
-DEVS_AFTER=$(lsblk -dno NAME | sort)
-CREATED_DEVICE=$(comm -13 <(echo "$DEVS_BEFORE") <(echo "$DEVS_AFTER") | grep -v '^loop' | head -1)
+CREATED_DEVICE=""
+for i in $(seq 1 10); do
+    CREATED_DEVICE=$(comm -13 <(echo "$DEVS_BEFORE") <(lsblk -dno NAME | sort) | grep -v '^loop' | head -1)
+    [ -n "$CREATED_DEVICE" ] && break
+    sleep 1
+done
 [ -z "$CREATED_DEVICE" ] && { echo "Error: no new block device appeared after loading g_mass_storage" >&2; exit 1; }
 echo "Info: fake device registered as /dev/$CREATED_DEVICE"
 

--- a/tests/can-actually-be-used/run-tests.sh
+++ b/tests/can-actually-be-used/run-tests.sh
@@ -26,10 +26,12 @@ for PUSB_FS_TYPE in vfat ext4 exfat; do
     echo "======================================================"
 
     # Teardown previous iteration's mount (skip on first)
+    # Use || true: test-agent-properly-triggers.sh unplugs the device at the end,
+    # leaving fakestick unmounted and g_mass_storage already unloaded.
     if [ -n "$PUSB_FS_TYPE_PREV" ]; then
         sync && sync && sync
-        sudo umount /tmp/fakestick
-        sudo modprobe -r g_mass_storage
+        sudo umount /tmp/fakestick 2>/dev/null || true
+        sudo modprobe -r g_mass_storage 2>/dev/null || true
         sudo udevadm settle
     fi
 

--- a/tests/can-actually-be-used/run-tests.sh
+++ b/tests/can-actually-be-used/run-tests.sh
@@ -2,22 +2,46 @@
 
 set -e
 
-# Make sure no old pads are around
-rm -rf /home/`whoami`/.pamusb
+for PUSB_FS_TYPE in vfat ext4 exfat; do
+    export PUSB_FS_TYPE
 
-# Run tests
-./test-keyring-unlock-gnome-installer.sh && \
-./test-pinentry-installer.sh && \
-./test-conf-detects-device.sh && \
-./test-conf-adds-device.sh && \
-./test-conf-adds-user.sh && \
-./test-conf-doesnt-add-user-twice-but-adds-a-second-device.sh && \
-./test-check-verify-created-config.sh && \
-./test-conf-reset-pads.sh && \
-./test-check-many-devices.sh && \
-./test-check-superuser-filtering.sh && \
-./test-conf-adds-user-with-superuser.sh && \
-./test-check-deny-xrdp-session.sh && \
-./test-check-debug-flag.sh && \
-rm -rf /tmp/fakestick/.pamusb && \
-./test-agent-properly-triggers.sh
+    if [ "$PUSB_FS_TYPE" = "exfat" ]; then
+        sudo modprobe exfat 2>/dev/null || { echo "Info: exfat kernel module not available, skipping exfat run"; continue; }
+    fi
+
+    echo ""
+    echo "======================================================"
+    echo "Running test suite with filesystem: $PUSB_FS_TYPE"
+    echo "======================================================"
+
+    # Teardown previous iteration's mount (skip on first)
+    if [ -n "$PUSB_FS_TYPE_PREV" ]; then
+        sync && sync && sync
+        sudo umount /tmp/fakestick
+        sudo modprobe -r g_mass_storage
+        sudo udevadm settle
+    fi
+
+    ./create-image.sh
+    ./mount-image.sh
+
+    rm -rf "/home/$(whoami)/.pamusb"
+
+    ./test-keyring-unlock-gnome-installer.sh && \
+    ./test-pinentry-installer.sh && \
+    ./test-conf-detects-device.sh && \
+    ./test-conf-adds-device.sh && \
+    ./test-conf-adds-user.sh && \
+    ./test-conf-doesnt-add-user-twice-but-adds-a-second-device.sh && \
+    ./test-check-verify-created-config.sh && \
+    ./test-conf-reset-pads.sh && \
+    ./test-check-many-devices.sh && \
+    ./test-check-superuser-filtering.sh && \
+    ./test-conf-adds-user-with-superuser.sh && \
+    ./test-check-deny-xrdp-session.sh && \
+    ./test-check-debug-flag.sh && \
+    rm -rf /tmp/fakestick/.pamusb && \
+    ./test-agent-properly-triggers.sh
+
+    PUSB_FS_TYPE_PREV=$PUSB_FS_TYPE
+done

--- a/tests/can-actually-be-used/run-tests.sh
+++ b/tests/can-actually-be-used/run-tests.sh
@@ -2,6 +2,17 @@
 
 set -e
 
+cleanup() {
+    local exit_code=$?
+    [ $exit_code -eq 0 ] && return 0
+    echo "Error: test suite failed (exit $exit_code), cleaning up..."
+    sync 2>/dev/null || true
+    sudo umount /tmp/fakestick 2>/dev/null || true
+    sudo modprobe -r g_mass_storage 2>/dev/null || true
+    sudo udevadm settle 2>/dev/null || true
+}
+trap cleanup EXIT
+
 for PUSB_FS_TYPE in vfat ext4 exfat; do
     export PUSB_FS_TYPE
 

--- a/tests/can-actually-be-used/setup-test-requirements.sh
+++ b/tests/can-actually-be-used/setup-test-requirements.sh
@@ -2,8 +2,7 @@
 
 set -e
 
-# Prepare testing
+# Prepare kernel modules for USB emulation; image creation and mounting is
+# handled by run-tests.sh per filesystem-type iteration.
 ./setup-dummyhcd.sh && \
-./prepare-mounting.sh && \
-./create-image.sh && \
-./mount-image.sh
+./prepare-mounting.sh

--- a/tests/can-actually-be-used/test-conf-doesnt-add-user-twice-but-adds-a-second-device.sh
+++ b/tests/can-actually-be-used/test-conf-doesnt-add-user-twice-but-adds-a-second-device.sh
@@ -14,8 +14,12 @@ sudo udevadm settle
 DEVS_BEFORE=$(lsblk -dno NAME | sort)
 sudo modprobe g_mass_storage file=./virtual_usb_alt.img stall=0 removable=y iSerialNumber=1234567891 iProduct=SecondStick || exit 1
 sudo udevadm settle
-DEVS_AFTER=$(lsblk -dno NAME | sort)
-CREATED_DEVICE=$(comm -13 <(echo "$DEVS_BEFORE") <(echo "$DEVS_AFTER") | grep -v '^loop' | head -1)
+CREATED_DEVICE=""
+for i in $(seq 1 10); do
+    CREATED_DEVICE=$(comm -13 <(echo "$DEVS_BEFORE") <(lsblk -dno NAME | sort) | grep -v '^loop' | head -1)
+    [ -n "$CREATED_DEVICE" ] && break
+    sleep 1
+done
 ./do-mount.sh "$PUSB_FS_TYPE" "/dev/${CREATED_DEVICE}1"
 
 echo -en "pamusb-conf --add-device output:\t" # to fake the unhideable python output as expected output :P

--- a/tests/can-actually-be-used/test-conf-doesnt-add-user-twice-but-adds-a-second-device.sh
+++ b/tests/can-actually-be-used/test-conf-doesnt-add-user-twice-but-adds-a-second-device.sh
@@ -13,14 +13,8 @@ sudo udevadm settle
 # "plug" another virtual usb (pre-formatted by mount-image.sh)
 sudo modprobe g_mass_storage file=./virtual_usb_alt.img stall=0 removable=y iSerialNumber=1234567891 iProduct=SecondStick || exit 1
 sudo udevadm settle
-CREATED_DEVICE=$(lsblk | grep 16M | awk '{ print $1 }')
-case "$PUSB_FS_TYPE" in
-    vfat|exfat)
-        sudo mount -t "$PUSB_FS_TYPE" "/dev/${CREATED_DEVICE}1" /tmp/fakestick -o rw,umask=0000 ;;
-    ext4)
-        sudo mount -t ext4 "/dev/${CREATED_DEVICE}1" /tmp/fakestick -o rw
-        sudo chmod 777 /tmp/fakestick ;;
-esac
+CREATED_DEVICE=$(lsblk -dno NAME,SIZE | grep '16M' | awk '{ print $1 }' | head -n 1)
+./do-mount.sh "$PUSB_FS_TYPE" "/dev/${CREATED_DEVICE}1"
 
 echo -en "pamusb-conf --add-device output:\t" # to fake the unhideable python output as expected output :P
 sudo pamusb-conf --add-device=test2 --device=0 --volume=0 --yes | grep "Done" && cat /etc/security/pam_usb.conf | grep "1234567891" > /dev/null && echo -e "Result:\t\t\tPASSED!" || exit 1

--- a/tests/can-actually-be-used/test-conf-doesnt-add-user-twice-but-adds-a-second-device.sh
+++ b/tests/can-actually-be-used/test-conf-doesnt-add-user-twice-but-adds-a-second-device.sh
@@ -2,17 +2,25 @@
 
 echo -e "Test:\t\t\tpamusb-conf doesn't add user(s) twice, but it adds a second device for an existing user"
 
+PUSB_FS_TYPE=${PUSB_FS_TYPE:-vfat}
+
 # "unplug" virtual usb
 sync && sync && sync
 sudo umount /tmp/fakestick
 sudo modprobe -r g_mass_storage || exit 1
-sleep 10
+sudo udevadm settle
 
-# "plug" another virtual usb
+# "plug" another virtual usb (pre-formatted by mount-image.sh)
 sudo modprobe g_mass_storage file=./virtual_usb_alt.img stall=0 removable=y iSerialNumber=1234567891 iProduct=SecondStick || exit 1
-sleep 10
+sudo udevadm settle
 CREATED_DEVICE=$(lsblk | grep 16M | awk '{ print $1 }')
-sudo mount -t vfat "/dev/"$CREATED_DEVICE"1" /tmp/fakestick -o rw,umask=0000
+case "$PUSB_FS_TYPE" in
+    vfat|exfat)
+        sudo mount -t "$PUSB_FS_TYPE" "/dev/${CREATED_DEVICE}1" /tmp/fakestick -o rw,umask=0000 ;;
+    ext4)
+        sudo mount -t ext4 "/dev/${CREATED_DEVICE}1" /tmp/fakestick -o rw
+        sudo chmod 777 /tmp/fakestick ;;
+esac
 
 echo -en "pamusb-conf --add-device output:\t" # to fake the unhideable python output as expected output :P
 sudo pamusb-conf --add-device=test2 --device=0 --volume=0 --yes | grep "Done" && cat /etc/security/pam_usb.conf | grep "1234567891" > /dev/null && echo -e "Result:\t\t\tPASSED!" || exit 1

--- a/tests/can-actually-be-used/test-conf-doesnt-add-user-twice-but-adds-a-second-device.sh
+++ b/tests/can-actually-be-used/test-conf-doesnt-add-user-twice-but-adds-a-second-device.sh
@@ -11,9 +11,11 @@ sudo modprobe -r g_mass_storage || exit 1
 sudo udevadm settle
 
 # "plug" another virtual usb (pre-formatted by mount-image.sh)
+DEVS_BEFORE=$(lsblk -dno NAME | sort)
 sudo modprobe g_mass_storage file=./virtual_usb_alt.img stall=0 removable=y iSerialNumber=1234567891 iProduct=SecondStick || exit 1
 sudo udevadm settle
-CREATED_DEVICE=$(lsblk -dno NAME,SIZE | grep '16M' | awk '{ print $1 }' | head -n 1)
+DEVS_AFTER=$(lsblk -dno NAME | sort)
+CREATED_DEVICE=$(comm -13 <(echo "$DEVS_BEFORE") <(echo "$DEVS_AFTER") | grep -v '^loop' | head -1)
 ./do-mount.sh "$PUSB_FS_TYPE" "/dev/${CREATED_DEVICE}1"
 
 echo -en "pamusb-conf --add-device output:\t" # to fake the unhideable python output as expected output :P


### PR DESCRIPTION
## Summary

- Switches `mount-image.sh` from offline-only formatting to online `mkfs` after `g_mass_storage` exposes the block device — required for ext4 and exFAT which don't support `--offset` on raw images
- Both `virtual_usb.img` and `virtual_usb_alt.img` are now pre-formatted in `mount-image.sh` via two load/format/unload cycles, so the alt-device test only needs to load and mount
- `run-tests.sh` wraps the full test sequence in a loop over `vfat`, `ext4`, `exfat`, calling `create-image.sh` + `mount-image.sh` per iteration with `PUSB_FS_TYPE` exported
- `udevadm settle` replaces all `sleep N` calls for reliable device readiness
- `setup-test-requirements.sh` now only loads kernel modules; image lifecycle is owned by `run-tests.sh`
- CI: adds `exfatprogs` to the apt install step; removes the now-redundant standalone `create-image.sh` and `mount-image.sh` steps
- exFAT iteration is skipped gracefully if the kernel module is unavailable (kernels < 5.7)

## Why this approach

The maintainer's analysis in the issue identified the exact technical constraints: offline formatting only works for vfat, and the loop should call `mount-image.sh` directly with `PUSB_FS_TYPE` set. This implementation follows that design. ext4 directly exercises the `fchown`/`fchmod` success path from the TOCTOU hardening in #371, which FAT32 never reaches due to always returning `EPERM`.

Closes #382

## Test plan

- [x] `./setup-test-requirements.sh && ./run-tests.sh` completes with PASSED for vfat, ext4, and exfat (or skip message for exfat on older kernels)
- [x] DoMagicOnConfiguredCustomRunner CI green

🤖 This PR was generated with the assistance of Claude Sonnet 4.6

I have read the rules