### PR TITLE
[Bug] Fix pinentry-pamusb.1.gz not removed on make deinstall (#414)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,6 +203,7 @@ $(PAMUSB_CHECK): $(OBJS) $(PAMUSB_CHECK_OBJS)
 clean:
 	$(RM) -f \
 		$(MANS) \
+		doc/pamusb-pinentry.1.gz \
 		$(PAM_USB) \
 		$(PAMUSB_CHECK) \
 		$(OBJS) \
@@ -265,6 +266,7 @@ deinstall:
 		$(POLKIT_CONF_DEST)/systemd-polkit-agent-helper-pamusb.conf
 
 	$(RM) -rf $(DOCS_DEST)
+	$(RM) -f $(addprefix $(MANS_DEST)/,$(notdir $(MANS)))
 	$(RM) -f $(MANS_DEST)/pamusb-*\.1\.gz
 	$(RM) -f $(PAM_CONF_DEST)/$(PAM_CONF)
 


### PR DESCRIPTION
## Summary

- The `deinstall` / `uninstall` target used the glob `pamusb-*.1.gz` to remove installed manpages, which matched `pamusb-{conf,agent,check,...}.1.gz` but **not** `pinentry-pamusb.1.gz` (different prefix after the tool rename in #343). The manpage was therefore left behind after `make deinstall`.
- Fixed by deriving the removal list directly from the `$(MANS)` variable via `$(addprefix $(MANS_DEST)/,$(notdir $(MANS)))`, keeping the old glob as a second pass for backward compatibility (removes old `pamusb-pinentry.1.gz` from systems upgraded from pre-rename installs).
- Also added `doc/pamusb-pinentry.1.gz` to the `clean` target so the orphaned pre-rename artifact is removed from developer workspaces.

## Technical approach

Using `$(addprefix $(MANS_DEST)/,$(notdir $(MANS)))` is the idiomatic Make approach: it derives the correct destination file names directly from the already-maintained `MANS` variable, so the deinstall target automatically stays in sync if the manpage list ever changes again. No manual glob maintenance required.

## Test plan

- [x] `make test` — 60/60 unit tests pass
- [x] `make manpages` — `doc/pinentry-pamusb.1.gz` created, `doc/pamusb-pinentry.1.gz` not recreated (no source `.1` file)
- [ ] `sudo make install` then `sudo make deinstall` — confirm `pinentry-pamusb.1.gz` is installed and then removed
- [x] `make build-debian && make build-fedora && make build-arch` — packaging succeeds

Integration test not feasible: install/uninstall path verification is a pure Makefile side-effect with no corresponding test harness in the suite.

Closes #414

🤖 This PR was generated with the assistance of Claude Sonnet 4.6

I have read the rules