### PR TITLE
[Security/Enhancement] Fix 7 deny_remote bypass vectors in tmux.c + shell unit tests (#419)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,7 @@ test-python:
 
 test-shell:
 	bash tests/unit/shell/loginctl_session_id_test.sh
+	bash tests/unit/shell/w_remote_detection_test.sh
 
 test: test-c test-python test-shell
 

--- a/src/tmux.c
+++ b/src/tmux.c
@@ -208,7 +208,13 @@ int pusb_tmux_has_remote_clients(const char* username)
 
         while (fgets(buf, BUFSIZ, fp) != NULL)
         {
-            snprintf(regex_raw, BUFSIZ, "%s%s", escaped_username, regex_tpl[i]);
+            int n = snprintf(regex_raw, BUFSIZ, "^%s%s", escaped_username, regex_tpl[i]);
+            if (n < 0 || (size_t)n >= BUFSIZ)
+            {
+                log_debug("		regex_raw buffer overflow for pattern %d.\n", i);
+                pclose(fp);
+                return -1;
+            }
 
             status = regcomp(&regex, regex_raw, REG_EXTENDED);
             if (status)

--- a/src/tmux.c
+++ b/src/tmux.c
@@ -157,7 +157,7 @@ char *pusb_tmux_get_client_tty(pid_t env_pid)
         tmux_client_tty += 5; /* strip /dev/ prefix */
         log_debug("		Got tmux_client_tty: %s\n", tmux_client_tty);
 
-        if (pclose(fp))
+        if (pclose(fp) == -1)
         {
             log_debug("		Closing pipe for 'tmux list-clients' failed, this is quite a wtf...\n");
         }
@@ -184,6 +184,12 @@ int pusb_tmux_has_remote_clients(const char* username)
     if (username == NULL)
     {
         log_error("Username is NULL, cannot check for remote tmux clients.\n");
+        return -1;
+    }
+
+    if (strlen(username) > 255)
+    {
+        log_error("Username exceeds 255 characters, denying to prevent regex bypass.\n");
         return -1;
     }
 
@@ -257,7 +263,7 @@ int pusb_tmux_has_remote_clients(const char* username)
 
     for (i = 0; i < 3; i++) regfree(&regex[i]);
 
-    if (pclose(fp))
+    if (pclose(fp) == -1)
     {
         log_debug("		Closing pipe for 'w' failed, this is quite a wtf...\n");
     }

--- a/src/tmux.c
+++ b/src/tmux.c
@@ -201,7 +201,7 @@ int pusb_tmux_has_remote_clients(const char* username)
     {
         log_debug("		Checking for IPv%d connections...\n", (4 + (i * 2)));
 
-        if ((fp = popen("LC_ALL=C; /usr/bin/w -i", "r")) == NULL)
+        if ((fp = popen("LC_ALL=C; /usr/bin/w -i", "re")) == NULL)
         {
             log_error("tmux detected, but couldn't get `w`. Denying since remote check for tmux impossible without it!\n");
             return -1;
@@ -219,7 +219,6 @@ int pusb_tmux_has_remote_clients(const char* username)
         if (status)
         {
             log_debug("		Couldn't compile regex!\n");
-            regfree(&regex);
             pclose(fp);
             return -1;
         }

--- a/src/tmux.c
+++ b/src/tmux.c
@@ -183,76 +183,78 @@ int pusb_tmux_has_remote_clients(const char* username)
 {
     int status;
     int n;
+    int i;
     FILE *fp;
-    regex_t regex;
+    regex_t regex[3];
     char regex_raw[BUFSIZ];
     char buf[BUFSIZ];
     char msgbuf[100];
+    int result = 0;
     const char *regex_tpl[3] = {
         "([[:space:]]+)([^[:space:]]+)([[:space:]]+)([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})([[:space:]]+)(.+)tmux(.+)", //v4: anchored to FROM field; prevents username-prefix false positives
         "([[:space:]]+)([^[:space:]]+)([[:space:]]+)(([0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4})[^[:space:]]*([[:space:]]+)(.+)tmux(.+)", // v6: anchored to FROM field; [^[:space:]]* absorbs zone index (e.g. %eth0)
         "([[:space:]]+)([^[:space:]]+)([[:space:]]+)::ffff:([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})([[:space:]]+)(.+)tmux(.+)" // v4-mapped v6 (::ffff:x.x.x.x): bypasses both above patterns without this
     }; // ... yes, these allow invalid addresses. No, I don't care. This isn't about validation but detecting remote access. Good enough ¯\_(ツ)_/¯
-    const char *proto_labels[3] = {"IPv4", "IPv6", "IPv4-mapped IPv6"};
 
     /* Max Linux username is 32 chars; doubled for escaping + null terminator = 65 bytes. */
     char escaped_username[65] = {0};
     pusb_tmux_escape_for_regex(username, escaped_username, sizeof(escaped_username));
 
-    for (int i = 0; i <= 2; i++)
+    for (i = 0; i < 3; i++)
     {
-        log_debug("		Checking for %s connections...\n", proto_labels[i]);
-
-        if ((fp = popen("LC_ALL=C; /usr/bin/w -i", "re")) == NULL)
-        {
-            log_error("tmux detected, but couldn't get `w`. Denying since remote check for tmux impossible without it!\n");
-            return -1;
-        }
-
         n = snprintf(regex_raw, BUFSIZ, "^%s%s", escaped_username, regex_tpl[i]);
         if (n < 0 || (size_t)n >= BUFSIZ)
         {
             log_debug("		regex_raw buffer overflow for pattern %d.\n", i);
-            pclose(fp);
+            for (int j = 0; j < i; j++) regfree(&regex[j]);
             return -1;
         }
 
-        status = regcomp(&regex, regex_raw, REG_EXTENDED);
+        status = regcomp(&regex[i], regex_raw, REG_EXTENDED);
         if (status)
         {
-            log_debug("		Couldn't compile regex!\n");
-            pclose(fp);
+            log_debug("		Couldn't compile regex %d!\n", i);
+            for (int j = 0; j < i; j++) regfree(&regex[j]);
             return -1;
-        }
-
-        while (fgets(buf, BUFSIZ, fp) != NULL)
-        {
-            status = regexec(&regex, buf, 0, NULL, 0);
-            if (!status)
-            {
-                log_error("tmux detected and at least one remote client is connected to the session, denying!\n");
-                regfree(&regex);
-                pclose(fp);
-                return 1;
-            }
-            else if (status != REG_NOMATCH)
-            {
-                regerror(status, &regex, msgbuf, sizeof(msgbuf));
-                log_debug("		Regex match failed: %s\n", msgbuf);
-                regfree(&regex);
-                pclose(fp);
-                return -1;
-            }
-        }
-
-        regfree(&regex);
-
-        if (pclose(fp))
-        {
-            log_debug("		Closing pipe for 'w' failed, this is quite a wtf...\n");
         }
     }
 
-    // If we had detected a remote access we would have returned by now. Safe to return 0 now
-    return 0;
+    if ((fp = popen("LC_ALL=C; /usr/bin/w -i", "re")) == NULL)
+    {
+        log_error("tmux detected, but couldn't get `w`. Denying since remote check for tmux impossible without it!\n");
+        for (i = 0; i < 3; i++) regfree(&regex[i]);
+        return -1;
+    }
+
+    while (fgets(buf, BUFSIZ, fp) != NULL)
+    {
+        for (i = 0; i < 3; i++)
+        {
+            status = regexec(&regex[i], buf, 0, NULL, 0);
+            if (!status)
+            {
+                log_error("tmux detected and at least one remote client is connected to the session, denying!\n");
+                result = 1;
+                break;
+            }
+            else if (status != REG_NOMATCH)
+            {
+                regerror(status, &regex[i], msgbuf, sizeof(msgbuf));
+                log_debug("		Regex match failed: %s\n", msgbuf);
+                result = -1;
+                break;
+            }
+        }
+        if (result != 0)
+            break;
+    }
+
+    for (i = 0; i < 3; i++) regfree(&regex[i]);
+
+    if (pclose(fp))
+    {
+        log_debug("		Closing pipe for 'w' failed, this is quite a wtf...\n");
+    }
+
+    return result;
 }

--- a/src/tmux.c
+++ b/src/tmux.c
@@ -189,7 +189,7 @@ int pusb_tmux_has_remote_clients(const char* username)
     char msgbuf[100];
     const char *regex_tpl[2] = {
         "(.+)([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})(.+)tmux(.+)", //v4
-        "(.+)([0-9A-Fa-f]{1,4}):([0-9A-Fa-f]{1,4}):([0-9A-Fa-f]{1,4}):([0-9A-Fa-f]{1,4})(.+)tmux(.+)" // v6
+        "(.+)(([0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4})(.+)tmux(.+)" // v6: {2,7} hex: groups handles both full and :: compressed addresses
     }; // ... yes, these allow invalid addresses. No, I don't care. This isn't about validation but detecting remote access. Good enough ¯\_(ツ)_/¯
 
     /* Max Linux username is 32 chars; doubled for escaping + null terminator = 65 bytes. */

--- a/src/tmux.c
+++ b/src/tmux.c
@@ -263,9 +263,19 @@ int pusb_tmux_has_remote_clients(const char* username)
 
     for (i = 0; i < 3; i++) regfree(&regex[i]);
 
-    if (pclose(fp) == -1)
+    int pclose_ret = pclose(fp);
+    if (pclose_ret == -1)
     {
         log_debug("		Closing pipe for 'w' failed, this is quite a wtf...\n");
+        if (result == 0)
+            result = -1;
+    }
+    else if (pclose_ret != 0 && result == 0)
+    {
+        /* w exited non-zero without us finding a match — command may have failed.
+         * Fail closed: treat as error rather than silently allowing access. */
+        log_error("w command exited with non-zero status, denying to be safe.\n");
+        result = -1;
     }
 
     return result;

--- a/src/tmux.c
+++ b/src/tmux.c
@@ -188,18 +188,20 @@ int pusb_tmux_has_remote_clients(const char* username)
     char regex_raw[BUFSIZ];
     char buf[BUFSIZ];
     char msgbuf[100];
-    const char *regex_tpl[2] = {
+    const char *regex_tpl[3] = {
         "([[:space:]]+)([^[:space:]]+)([[:space:]]+)([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})([[:space:]]+)(.+)tmux(.+)", //v4: anchored to FROM field; prevents username-prefix false positives
-        "([[:space:]]+)([^[:space:]]+)([[:space:]]+)(([0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4})([[:space:]]+)(.+)tmux(.+)" // v6: anchored to FROM field; prevents HH:MM:SS time fields from false-matching
+        "([[:space:]]+)([^[:space:]]+)([[:space:]]+)(([0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4})([[:space:]]+)(.+)tmux(.+)", // v6: anchored to FROM field; prevents HH:MM:SS time fields from false-matching
+        "([[:space:]]+)([^[:space:]]+)([[:space:]]+)::ffff:([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})([[:space:]]+)(.+)tmux(.+)" // v4-mapped v6 (::ffff:x.x.x.x): bypasses both above patterns without this
     }; // ... yes, these allow invalid addresses. No, I don't care. This isn't about validation but detecting remote access. Good enough ¯\_(ツ)_/¯
+    const char *proto_labels[3] = {"IPv4", "IPv6", "IPv4-mapped IPv6"};
 
     /* Max Linux username is 32 chars; doubled for escaping + null terminator = 65 bytes. */
     char escaped_username[65] = {0};
     pusb_tmux_escape_for_regex(username, escaped_username, sizeof(escaped_username));
 
-    for (int i = 0; i <= 1; i++)
+    for (int i = 0; i <= 2; i++)
     {
-        log_debug("		Checking for IPv%d connections...\n", (4 + (i * 2)));
+        log_debug("		Checking for %s connections...\n", proto_labels[i]);
 
         if ((fp = popen("LC_ALL=C; /usr/bin/w -i", "re")) == NULL)
         {

--- a/src/tmux.c
+++ b/src/tmux.c
@@ -181,6 +181,12 @@ char *pusb_tmux_get_client_tty(pid_t env_pid)
  */
 int pusb_tmux_has_remote_clients(const char* username)
 {
+    if (username == NULL)
+    {
+        log_error("Username is NULL, cannot check for remote tmux clients.\n");
+        return -1;
+    }
+
     int status;
     int n;
     int i;
@@ -196,8 +202,8 @@ int pusb_tmux_has_remote_clients(const char* username)
         "([[:space:]]+)([^[:space:]]+)([[:space:]]+)::ffff:([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})([[:space:]]+)(.+)tmux(.+)" // v4-mapped v6 (::ffff:x.x.x.x): bypasses both above patterns without this
     }; // ... yes, these allow invalid addresses. No, I don't care. This isn't about validation but detecting remote access. Good enough ¯\_(ツ)_/¯
 
-    /* Max Linux username is 32 chars; doubled for escaping + null terminator = 65 bytes. */
-    char escaped_username[65] = {0};
+    /* Up to 255-char usernames (SSSD/AD); doubled for escaping + null terminator = 511, rounded to 512. */
+    char escaped_username[512] = {0};
     pusb_tmux_escape_for_regex(username, escaped_username, sizeof(escaped_username));
 
     for (i = 0; i < 3; i++)

--- a/src/tmux.c
+++ b/src/tmux.c
@@ -189,7 +189,7 @@ int pusb_tmux_has_remote_clients(const char* username)
     char msgbuf[100];
     const char *regex_tpl[2] = {
         "(.+)([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})(.+)tmux(.+)", //v4
-        "(.+)(([0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4})(.+)tmux(.+)" // v6: {2,7} hex: groups handles both full and :: compressed addresses
+        "([[:space:]]+)([^[:space:]]+)([[:space:]]+)(([0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4})([[:space:]]+)(.+)tmux(.+)" // v6: anchored to FROM field; prevents HH:MM:SS time fields from false-matching
     }; // ... yes, these allow invalid addresses. No, I don't care. This isn't about validation but detecting remote access. Good enough ¯\_(ツ)_/¯
 
     /* Max Linux username is 32 chars; doubled for escaping + null terminator = 65 bytes. */

--- a/src/tmux.c
+++ b/src/tmux.c
@@ -182,6 +182,7 @@ char *pusb_tmux_get_client_tty(pid_t env_pid)
 int pusb_tmux_has_remote_clients(const char* username)
 {
     int status;
+    int n;
     FILE *fp;
     regex_t regex;
     char regex_raw[BUFSIZ];
@@ -206,25 +207,25 @@ int pusb_tmux_has_remote_clients(const char* username)
             return -1;
         }
 
+        n = snprintf(regex_raw, BUFSIZ, "^%s%s", escaped_username, regex_tpl[i]);
+        if (n < 0 || (size_t)n >= BUFSIZ)
+        {
+            log_debug("		regex_raw buffer overflow for pattern %d.\n", i);
+            pclose(fp);
+            return -1;
+        }
+
+        status = regcomp(&regex, regex_raw, REG_EXTENDED);
+        if (status)
+        {
+            log_debug("		Couldn't compile regex!\n");
+            regfree(&regex);
+            pclose(fp);
+            return -1;
+        }
+
         while (fgets(buf, BUFSIZ, fp) != NULL)
         {
-            int n = snprintf(regex_raw, BUFSIZ, "^%s%s", escaped_username, regex_tpl[i]);
-            if (n < 0 || (size_t)n >= BUFSIZ)
-            {
-                log_debug("		regex_raw buffer overflow for pattern %d.\n", i);
-                pclose(fp);
-                return -1;
-            }
-
-            status = regcomp(&regex, regex_raw, REG_EXTENDED);
-            if (status)
-            {
-                log_debug("		Couldn't compile regex!\n");
-                regfree(&regex);
-                pclose(fp);
-                return -1;
-            }
-
             status = regexec(&regex, buf, 0, NULL, 0);
             if (!status)
             {
@@ -241,9 +242,9 @@ int pusb_tmux_has_remote_clients(const char* username)
                 pclose(fp);
                 return -1;
             }
-
-            regfree(&regex);
         }
+
+        regfree(&regex);
 
         if (pclose(fp))
         {

--- a/src/tmux.c
+++ b/src/tmux.c
@@ -187,7 +187,7 @@ int pusb_tmux_has_remote_clients(const char* username)
         return -1;
     }
 
-    if (strlen(username) > 255)
+    if (strlen(username) > 255) /* DevSkim: ignore DS140021 - username is a PAM-provided NUL-terminated string */
     {
         log_error("Username exceeds 255 characters, denying to prevent regex bypass.\n");
         return -1;
@@ -222,7 +222,7 @@ int pusb_tmux_has_remote_clients(const char* username)
             return -1;
         }
 
-        status = regcomp(&regex[i], regex_raw, REG_EXTENDED);
+        status = regcomp(&regex[i], regex_raw, REG_EXTENDED | REG_NOSUB);
         if (status)
         {
             log_debug("		Couldn't compile regex %d!\n", i);

--- a/src/tmux.c
+++ b/src/tmux.c
@@ -190,7 +190,7 @@ int pusb_tmux_has_remote_clients(const char* username)
     char msgbuf[100];
     const char *regex_tpl[3] = {
         "([[:space:]]+)([^[:space:]]+)([[:space:]]+)([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})([[:space:]]+)(.+)tmux(.+)", //v4: anchored to FROM field; prevents username-prefix false positives
-        "([[:space:]]+)([^[:space:]]+)([[:space:]]+)(([0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4})([[:space:]]+)(.+)tmux(.+)", // v6: anchored to FROM field; prevents HH:MM:SS time fields from false-matching
+        "([[:space:]]+)([^[:space:]]+)([[:space:]]+)(([0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4})[^[:space:]]*([[:space:]]+)(.+)tmux(.+)", // v6: anchored to FROM field; [^[:space:]]* absorbs zone index (e.g. %eth0)
         "([[:space:]]+)([^[:space:]]+)([[:space:]]+)::ffff:([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})([[:space:]]+)(.+)tmux(.+)" // v4-mapped v6 (::ffff:x.x.x.x): bypasses both above patterns without this
     }; // ... yes, these allow invalid addresses. No, I don't care. This isn't about validation but detecting remote access. Good enough ¯\_(ツ)_/¯
     const char *proto_labels[3] = {"IPv4", "IPv6", "IPv4-mapped IPv6"};

--- a/src/tmux.c
+++ b/src/tmux.c
@@ -188,7 +188,7 @@ int pusb_tmux_has_remote_clients(const char* username)
     char buf[BUFSIZ];
     char msgbuf[100];
     const char *regex_tpl[2] = {
-        "(.+)([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})(.+)tmux(.+)", //v4
+        "([[:space:]]+)([^[:space:]]+)([[:space:]]+)([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})\\.([0-9]{1,3})([[:space:]]+)(.+)tmux(.+)", //v4: anchored to FROM field; prevents username-prefix false positives
         "([[:space:]]+)([^[:space:]]+)([[:space:]]+)(([0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4})([[:space:]]+)(.+)tmux(.+)" // v6: anchored to FROM field; prevents HH:MM:SS time fields from false-matching
     }; // ... yes, these allow invalid addresses. No, I don't care. This isn't about validation but detecting remote access. Good enough ¯\_(ツ)_/¯
 
@@ -200,7 +200,7 @@ int pusb_tmux_has_remote_clients(const char* username)
     {
         log_debug("		Checking for IPv%d connections...\n", (4 + (i * 2)));
 
-        if ((fp = popen("LC_ALL=C; /usr/bin/w", "r")) == NULL)
+        if ((fp = popen("LC_ALL=C; /usr/bin/w -i", "r")) == NULL)
         {
             log_error("tmux detected, but couldn't get `w`. Denying since remote check for tmux impossible without it!\n");
             return -1;

--- a/tests/unit/c/tmux_test.c
+++ b/tests/unit/c/tmux_test.c
@@ -185,6 +185,15 @@ static void test_has_remote_ipv6_compressed_typical(void **state)
 	assert_int_equal(1, pusb_tmux_has_remote_clients("testuser"));
 }
 
+static void test_has_remote_ipv4_mapped(void **state)
+{
+	(void)state;
+	/* ::ffff:x.x.x.x bypasses the pure-IPv4 pattern (::ffff: prefix) and
+	 * the pure-IPv6 pattern (dotted suffix) without a dedicated template. */
+	g_popen_output = "testuser pts/1   ::ffff:192.168.1.100  10:00   0.00s  tmux attach\n";
+	assert_int_equal(1, pusb_tmux_has_remote_clients("testuser"));
+}
+
 static void test_has_remote_ipv6_no_false_positive_hhmmss(void **state)
 {
 	(void)state;
@@ -357,6 +366,7 @@ int main(void)
 		cmocka_unit_test(test_escape_empty_input),
 		cmocka_unit_test(test_has_remote_ipv4),
 		cmocka_unit_test(test_has_remote_ipv6),
+		cmocka_unit_test(test_has_remote_ipv4_mapped),
 		cmocka_unit_test(test_has_remote_ipv6_compressed_loopback),
 		cmocka_unit_test(test_has_remote_ipv6_compressed_linklocal),
 		cmocka_unit_test(test_has_remote_ipv6_compressed_typical),

--- a/tests/unit/c/tmux_test.c
+++ b/tests/unit/c/tmux_test.c
@@ -194,6 +194,14 @@ static void test_has_remote_ipv4_mapped(void **state)
 	assert_int_equal(1, pusb_tmux_has_remote_clients("testuser"));
 }
 
+static void test_has_remote_ipv6_linklocal_zone_index(void **state)
+{
+	(void)state;
+	/* fe80::1%eth0: zone index after address must not prevent detection */
+	g_popen_output = "testuser pts/1   fe80::1%eth0  10:00   0.00s  tmux attach\n";
+	assert_int_equal(1, pusb_tmux_has_remote_clients("testuser"));
+}
+
 static void test_has_remote_ipv6_no_false_positive_hhmmss(void **state)
 {
 	(void)state;
@@ -369,6 +377,7 @@ int main(void)
 		cmocka_unit_test(test_has_remote_ipv4_mapped),
 		cmocka_unit_test(test_has_remote_ipv6_compressed_loopback),
 		cmocka_unit_test(test_has_remote_ipv6_compressed_linklocal),
+		cmocka_unit_test(test_has_remote_ipv6_linklocal_zone_index),
 		cmocka_unit_test(test_has_remote_ipv6_compressed_typical),
 		cmocka_unit_test(test_has_remote_ipv6_no_false_positive_hhmmss),
 		cmocka_unit_test(test_has_remote_local_display),

--- a/tests/unit/c/tmux_test.c
+++ b/tests/unit/c/tmux_test.c
@@ -145,6 +145,12 @@ static void test_escape_empty_input(void **state)
 
 /* ── pusb_tmux_has_remote_clients ── */
 
+static void test_has_remote_null_username(void **state)
+{
+	(void)state;
+	assert_int_equal(-1, pusb_tmux_has_remote_clients(NULL));
+}
+
 static void test_has_remote_ipv4(void **state)
 {
 	(void)state;
@@ -372,6 +378,7 @@ int main(void)
 		cmocka_unit_test(test_escape_plus),
 		cmocka_unit_test(test_escape_all_metacharacters),
 		cmocka_unit_test(test_escape_empty_input),
+		cmocka_unit_test(test_has_remote_null_username),
 		cmocka_unit_test(test_has_remote_ipv4),
 		cmocka_unit_test(test_has_remote_ipv6),
 		cmocka_unit_test(test_has_remote_ipv4_mapped),

--- a/tests/unit/c/tmux_test.c
+++ b/tests/unit/c/tmux_test.c
@@ -151,6 +151,16 @@ static void test_has_remote_null_username(void **state)
 	assert_int_equal(-1, pusb_tmux_has_remote_clients(NULL));
 }
 
+static void test_has_remote_username_too_long(void **state)
+{
+	(void)state;
+	/* 256-char username must be rejected to prevent silent regex truncation bypass */
+	char long_username[257];
+	memset(long_username, 'a', 256);
+	long_username[256] = '\0';
+	assert_int_equal(-1, pusb_tmux_has_remote_clients(long_username));
+}
+
 static void test_has_remote_ipv4(void **state)
 {
 	(void)state;
@@ -379,6 +389,7 @@ int main(void)
 		cmocka_unit_test(test_escape_all_metacharacters),
 		cmocka_unit_test(test_escape_empty_input),
 		cmocka_unit_test(test_has_remote_null_username),
+		cmocka_unit_test(test_has_remote_username_too_long),
 		cmocka_unit_test(test_has_remote_ipv4),
 		cmocka_unit_test(test_has_remote_ipv6),
 		cmocka_unit_test(test_has_remote_ipv4_mapped),

--- a/tests/unit/c/tmux_test.c
+++ b/tests/unit/c/tmux_test.c
@@ -209,6 +209,15 @@ static void test_has_remote_empty_output(void **state)
 	assert_int_equal(0, pusb_tmux_has_remote_clients("testuser"));
 }
 
+static void test_has_remote_ipv4_username_prefix_no_match(void **state)
+{
+	(void)state;
+	/* "testuser2" must not match a check for "testuser": the old (.+) prefix
+	 * allowed the regex to consume "2 pts/0" as part of the match. */
+	g_popen_output = "testuser2 pts/0   192.168.1.100  10:00   0.00s  tmux attach\n";
+	assert_int_equal(0, pusb_tmux_has_remote_clients("testuser"));
+}
+
 static void test_has_remote_wrong_user_dot_regression(void **state)
 {
 	(void)state;
@@ -345,6 +354,7 @@ int main(void)
 		cmocka_unit_test(test_has_remote_ipv6_no_false_positive_hhmmss),
 		cmocka_unit_test(test_has_remote_local_display),
 		cmocka_unit_test(test_has_remote_empty_output),
+		cmocka_unit_test(test_has_remote_ipv4_username_prefix_no_match),
 		cmocka_unit_test(test_has_remote_wrong_user_dot_regression),
 		cmocka_unit_test(test_get_client_tty_no_tmux_env),
 		cmocka_unit_test(test_get_client_tty_injection_semicolon),

--- a/tests/unit/c/tmux_test.c
+++ b/tests/unit/c/tmux_test.c
@@ -161,6 +161,30 @@ static void test_has_remote_ipv6(void **state)
 	assert_int_equal(1, pusb_tmux_has_remote_clients("testuser"));
 }
 
+static void test_has_remote_ipv6_compressed_loopback(void **state)
+{
+	(void)state;
+	/* ::1 is compressed IPv6 loopback — old 4-group pattern missed this */
+	g_popen_output = "testuser pts/1   ::1  10:00   0.00s  tmux attach\n";
+	assert_int_equal(1, pusb_tmux_has_remote_clients("testuser"));
+}
+
+static void test_has_remote_ipv6_compressed_linklocal(void **state)
+{
+	(void)state;
+	/* fe80::1 is a compressed link-local address — old 4-group pattern missed this */
+	g_popen_output = "testuser pts/1   fe80::1  10:00   0.00s  tmux attach\n";
+	assert_int_equal(1, pusb_tmux_has_remote_clients("testuser"));
+}
+
+static void test_has_remote_ipv6_compressed_typical(void **state)
+{
+	(void)state;
+	/* 2001:db8::1 is a typical compressed address — old 4-group pattern missed this */
+	g_popen_output = "testuser pts/1   2001:db8::1  10:00   0.00s  tmux attach\n";
+	assert_int_equal(1, pusb_tmux_has_remote_clients("testuser"));
+}
+
 static void test_has_remote_local_display(void **state)
 {
 	(void)state;
@@ -306,6 +330,9 @@ int main(void)
 		cmocka_unit_test(test_escape_empty_input),
 		cmocka_unit_test(test_has_remote_ipv4),
 		cmocka_unit_test(test_has_remote_ipv6),
+		cmocka_unit_test(test_has_remote_ipv6_compressed_loopback),
+		cmocka_unit_test(test_has_remote_ipv6_compressed_linklocal),
+		cmocka_unit_test(test_has_remote_ipv6_compressed_typical),
 		cmocka_unit_test(test_has_remote_local_display),
 		cmocka_unit_test(test_has_remote_empty_output),
 		cmocka_unit_test(test_has_remote_wrong_user_dot_regression),

--- a/tests/unit/c/tmux_test.c
+++ b/tests/unit/c/tmux_test.c
@@ -28,6 +28,7 @@
 
 static const char *g_popen_output = "";
 static char g_last_popen_cmd[BUFSIZ];
+static int g_pclose_ret = 0;
 
 FILE *__wrap_popen(const char *cmd, const char *type)
 {
@@ -38,7 +39,7 @@ FILE *__wrap_popen(const char *cmd, const char *type)
 int __wrap_pclose(FILE *fp)
 {
 	fclose(fp);
-	return 0;
+	return g_pclose_ret;
 }
 
 /* ── pusb_tmux_is_safe_socket_path ── */
@@ -242,6 +243,26 @@ static void test_has_remote_empty_output(void **state)
 	assert_int_equal(0, pusb_tmux_has_remote_clients("testuser"));
 }
 
+static void test_has_remote_w_nonzero_exit_denies(void **state)
+{
+	(void)state;
+	/* w exiting non-zero with no match found must deny (fail-closed), not allow */
+	g_popen_output = "";
+	g_pclose_ret = 1;
+	assert_int_equal(-1, pusb_tmux_has_remote_clients("testuser"));
+	g_pclose_ret = 0;
+}
+
+static void test_has_remote_w_nonzero_exit_does_not_override_match(void **state)
+{
+	(void)state;
+	/* If a remote client was already found, a non-zero w exit must not suppress it */
+	g_popen_output = "testuser pts/1   192.168.1.100  10:00   0.00s  tmux attach\n";
+	g_pclose_ret = 1;
+	assert_int_equal(1, pusb_tmux_has_remote_clients("testuser"));
+	g_pclose_ret = 0;
+}
+
 static void test_has_remote_ipv4_username_suffix_no_match(void **state)
 {
 	(void)state;
@@ -400,6 +421,8 @@ int main(void)
 		cmocka_unit_test(test_has_remote_ipv6_no_false_positive_hhmmss),
 		cmocka_unit_test(test_has_remote_local_display),
 		cmocka_unit_test(test_has_remote_empty_output),
+		cmocka_unit_test(test_has_remote_w_nonzero_exit_denies),
+		cmocka_unit_test(test_has_remote_w_nonzero_exit_does_not_override_match),
 		cmocka_unit_test(test_has_remote_ipv4_username_suffix_no_match),
 		cmocka_unit_test(test_has_remote_ipv4_username_prefix_no_match),
 		cmocka_unit_test(test_has_remote_wrong_user_dot_regression),

--- a/tests/unit/c/tmux_test.c
+++ b/tests/unit/c/tmux_test.c
@@ -185,6 +185,15 @@ static void test_has_remote_ipv6_compressed_typical(void **state)
 	assert_int_equal(1, pusb_tmux_has_remote_clients("testuser"));
 }
 
+static void test_has_remote_ipv6_no_false_positive_hhmmss(void **state)
+{
+	(void)state;
+	/* Local session: FROM='-', but idle/login time contains HH:MM:SS colons.
+	 * The anchored FROM-field pattern must not mistake a time field for IPv6. */
+	g_popen_output = "testuser pts/2   -  10:00:00   0.00s  tmux attach\n";
+	assert_int_equal(0, pusb_tmux_has_remote_clients("testuser"));
+}
+
 static void test_has_remote_local_display(void **state)
 {
 	(void)state;
@@ -333,6 +342,7 @@ int main(void)
 		cmocka_unit_test(test_has_remote_ipv6_compressed_loopback),
 		cmocka_unit_test(test_has_remote_ipv6_compressed_linklocal),
 		cmocka_unit_test(test_has_remote_ipv6_compressed_typical),
+		cmocka_unit_test(test_has_remote_ipv6_no_false_positive_hhmmss),
 		cmocka_unit_test(test_has_remote_local_display),
 		cmocka_unit_test(test_has_remote_empty_output),
 		cmocka_unit_test(test_has_remote_wrong_user_dot_regression),

--- a/tests/unit/c/tmux_test.c
+++ b/tests/unit/c/tmux_test.c
@@ -209,6 +209,15 @@ static void test_has_remote_empty_output(void **state)
 	assert_int_equal(0, pusb_tmux_has_remote_clients("testuser"));
 }
 
+static void test_has_remote_ipv4_username_suffix_no_match(void **state)
+{
+	(void)state;
+	/* "mytestuser" must not match a check for "testuser": without ^ the regex
+	 * could match "testuser" as a substring at a non-zero offset. */
+	g_popen_output = "mytestuser pts/0   192.168.1.100  10:00   0.00s  tmux attach\n";
+	assert_int_equal(0, pusb_tmux_has_remote_clients("testuser"));
+}
+
 static void test_has_remote_ipv4_username_prefix_no_match(void **state)
 {
 	(void)state;
@@ -354,6 +363,7 @@ int main(void)
 		cmocka_unit_test(test_has_remote_ipv6_no_false_positive_hhmmss),
 		cmocka_unit_test(test_has_remote_local_display),
 		cmocka_unit_test(test_has_remote_empty_output),
+		cmocka_unit_test(test_has_remote_ipv4_username_suffix_no_match),
 		cmocka_unit_test(test_has_remote_ipv4_username_prefix_no_match),
 		cmocka_unit_test(test_has_remote_wrong_user_dot_regression),
 		cmocka_unit_test(test_get_client_tty_no_tmux_env),

--- a/tests/unit/shell/loginctl_session_id_test.sh
+++ b/tests/unit/shell/loginctl_session_id_test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # Tests that the loginctl session ID extraction pipeline handles both
 # alphanumeric IDs (e.g. "c2", "c6" — graphical sessions on modern systemd)
 # and pure numeric IDs (e.g. "42" — legacy/TTY sessions).
@@ -18,7 +19,16 @@ extract_session_id() {
 # Here we short-circuit the actual loginctl call and just echo a canned response.
 extract_with_guard() {
     local session_id="$1" canned_output="$2"
-    [ -n "$session_id" ] && printf '%s\n' "$canned_output"
+    if [ -n "$session_id" ]; then
+        printf '%s\n' "$canned_output"
+    fi
+}
+
+# Mirror the awk pipeline used in pusb_get_loginctl_session_property:
+#   loginctl show-session "$ID" -p KEY | awk -F= '{print $2}'
+# loginctl outputs "KEY=value"; awk splits on '=' and returns field 2.
+extract_property_value() {
+    printf '%s\n' "$1" | awk -F= '{print $2}'
 }
 
 assert_eq() {
@@ -92,6 +102,12 @@ assert_eq "no session line → empty"                   ""    "$(extract_session
 # Non-empty session ID guard: loginctl show-session is only called when ID was found
 assert_eq "guard: non-empty ID passes through"  "tty7" "$(extract_with_guard "c2"  "tty7")"
 assert_eq "guard: empty ID suppresses output"   ""     "$(extract_with_guard ""    "tty7")"
+
+# loginctl show-session awk field extraction (awk -F= '{print $2}')
+assert_eq "awk: TTY field"           "tty7"       "$(extract_property_value "TTY=tty7")"
+assert_eq "awk: Remote field"        "no"         "$(extract_property_value "Remote=no")"
+assert_eq "awk: empty input"         ""           "$(extract_property_value "")"
+assert_eq "awk: multi-= value (pts)" "/dev/pts/0" "$(extract_property_value "TTY=/dev/pts/0=1")"
 
 # --- summary ---
 echo "---"

--- a/tests/unit/shell/loginctl_session_id_test.sh
+++ b/tests/unit/shell/loginctl_session_id_test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+export LC_ALL=C
 # Tests that the loginctl session ID extraction pipeline handles both
 # alphanumeric IDs (e.g. "c2", "c6" — graphical sessions on modern systemd)
 # and pure numeric IDs (e.g. "42" — legacy/TTY sessions).
@@ -31,8 +32,10 @@ extract_with_guard() {
 # loginctl outputs "KEY=value"; pure-Bash expansion avoids the awk subshell
 # and any SIGPIPE risk from a printf|awk pipeline under set -o pipefail.
 extract_property_value() {
-    local val="${1#*=}"
-    printf '%s\n' "${val%%=*}"
+    if [[ "$1" =~ = ]]; then
+        local val="${1#*=}"
+        printf '%s\n' "${val%%=*}"
+    fi
 }
 
 assert_eq() {

--- a/tests/unit/shell/loginctl_session_id_test.sh
+++ b/tests/unit/shell/loginctl_session_id_test.sh
@@ -9,9 +9,11 @@ fail=0
 
 extract_session_id() {
     # Mirror the pipeline used in pusb_get_loginctl_session_property (via pusb_get_tty_by_loginctl /
-    # pusb_is_loginctl_local). A single sed replaces the previous grep | grep | sed chain.
-    printf '%s\n' "$1" \
-        | sed -n 's/.*session-\([a-zA-Z0-9]\+\)\.scope.*/\1/p;T;q'
+    # pusb_is_loginctl_local). Pure-Bash regex avoids the SIGPIPE risk that sed -n ...;q causes
+    # under set -o pipefail when the preceding printf is still writing.
+    if [[ "$1" =~ session-([a-zA-Z0-9]+)\.scope ]]; then
+        printf '%s\n' "${BASH_REMATCH[1]}"
+    fi
 }
 
 # Simulate the guarded show-session call: only proceeds when session ID is non-empty.
@@ -26,9 +28,11 @@ extract_with_guard() {
 
 # Mirror the awk pipeline used in pusb_get_loginctl_session_property:
 #   loginctl show-session "$ID" -p KEY | awk -F= '{print $2}'
-# loginctl outputs "KEY=value"; awk splits on '=' and returns field 2.
+# loginctl outputs "KEY=value"; pure-Bash expansion avoids the awk subshell
+# and any SIGPIPE risk from a printf|awk pipeline under set -o pipefail.
 extract_property_value() {
-    printf '%s\n' "$1" | awk -F= '{print $2}'
+    local val="${1#*=}"
+    printf '%s\n' "${val%%=*}"
 }
 
 assert_eq() {

--- a/tests/unit/shell/w_remote_detection_test.sh
+++ b/tests/unit/shell/w_remote_detection_test.sh
@@ -16,7 +16,7 @@ PAT_IPV4="${TESTUSER}(.+)([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})(
 PAT_IPV6="${TESTUSER}(.+)([0-9A-Fa-f]{1,4}):([0-9A-Fa-f]{1,4}):([0-9A-Fa-f]{1,4}):([0-9A-Fa-f]{1,4})(.+)tmux(.+)"
 
 matches_pattern() {
-    printf '%s\n' "$2" | grep -qE "$1"
+    [[ "$2" =~ $1 ]]
 }
 
 assert_match() {

--- a/tests/unit/shell/w_remote_detection_test.sh
+++ b/tests/unit/shell/w_remote_detection_test.sh
@@ -14,7 +14,7 @@ fail=0
 # Patterns copied verbatim from src/tmux.c:191-192, prefixed with the test username.
 TESTUSER="testuser"
 PAT_IPV4="${TESTUSER}(.+)([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})(.+)tmux(.+)"
-PAT_IPV6="${TESTUSER}(.+)([0-9A-Fa-f]{1,4}):([0-9A-Fa-f]{1,4}):([0-9A-Fa-f]{1,4}):([0-9A-Fa-f]{1,4})(.+)tmux(.+)"
+PAT_IPV6="${TESTUSER}(.+)(([0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4})(.+)tmux(.+)"
 
 matches_pattern() {
     [[ "$2" =~ $1 ]]
@@ -46,6 +46,9 @@ assert_no_match() {
 
 LINE_IPV4_TMUX="testuser pts/0    192.168.1.100    10:00    0.00s 0.01s 0.00s tmux: client"
 LINE_IPV6_TMUX="testuser pts/1    fe80:0:0:1       10:00    0.00s 0.01s 0.00s tmux: client"
+LINE_IPV6_LOOPBACK="testuser pts/2    ::1              10:00    0.00s 0.01s 0.00s tmux: client"
+LINE_IPV6_LINKLOCAL="testuser pts/3    fe80::1          10:00    0.00s 0.01s 0.00s tmux: client"
+LINE_IPV6_TYPICAL="testuser pts/4    2001:db8::1      10:00    0.00s 0.01s 0.00s tmux: client"
 LINE_LOCAL_TMUX="testuser pts/2    -                10:00    0.00s 0.01s 0.00s tmux: client"
 LINE_IPV4_SSH="testuser pts/3    192.168.1.100    10:00    0.00s 0.01s 0.00s ssh"
 LINE_X11_TMUX="testuser pts/4    :0               10:00    0.00s 0.01s 0.00s tmux: client"
@@ -56,8 +59,11 @@ LINE_OTHER_USER="otheruser pts/0   192.168.1.100    10:00    0.00s 0.01s 0.00s t
 # IPv4 remote tmux → should match (remote client detected)
 assert_match    "IPv4: remote IP + tmux → match"          "$PAT_IPV4" "$LINE_IPV4_TMUX"
 
-# IPv6 remote tmux → should match
-assert_match    "IPv6: remote IP + tmux → match"          "$PAT_IPV6" "$LINE_IPV6_TMUX"
+# IPv6 remote tmux → should match (full and compressed forms)
+assert_match    "IPv6: full 4-group + tmux → match"              "$PAT_IPV6" "$LINE_IPV6_TMUX"
+assert_match    "IPv6: compressed ::1 (loopback) + tmux → match" "$PAT_IPV6" "$LINE_IPV6_LOOPBACK"
+assert_match    "IPv6: compressed fe80::1 (link-local) + tmux → match" "$PAT_IPV6" "$LINE_IPV6_LINKLOCAL"
+assert_match    "IPv6: compressed 2001:db8::1 + tmux → match"   "$PAT_IPV6" "$LINE_IPV6_TYPICAL"
 
 # Local login (FROM='-') + tmux → no remote IP, should not match either pattern
 assert_no_match "IPv4: local TTY (FROM=-) + tmux → no match"  "$PAT_IPV4" "$LINE_LOCAL_TMUX"

--- a/tests/unit/shell/w_remote_detection_test.sh
+++ b/tests/unit/shell/w_remote_detection_test.sh
@@ -13,8 +13,8 @@ fail=0
 
 # Patterns copied verbatim from src/tmux.c:191-192, prefixed with the test username.
 TESTUSER="testuser"
-PAT_IPV4="${TESTUSER}([[:space:]]+)([^[:space:]]+)([[:space:]]+)([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})([[:space:]]+)(.+)tmux(.+)"
-PAT_IPV6="${TESTUSER}([[:space:]]+)([^[:space:]]+)([[:space:]]+)(([0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4})([[:space:]]+)(.+)tmux(.+)"
+PAT_IPV4="^${TESTUSER}([[:space:]]+)([^[:space:]]+)([[:space:]]+)([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})([[:space:]]+)(.+)tmux(.+)"
+PAT_IPV6="^${TESTUSER}([[:space:]]+)([^[:space:]]+)([[:space:]]+)(([0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4})([[:space:]]+)(.+)tmux(.+)"
 
 matches_pattern() {
     [[ "$2" =~ $1 ]]
@@ -82,6 +82,9 @@ assert_no_match "IPv6: X11 :0 + tmux → no match"          "$PAT_IPV6" "$LINE_X
 assert_no_match "IPv4: wrong username → no match"          "$PAT_IPV4" "$LINE_OTHER_USER"
 # Username extension → "testuser2" must not match a pattern anchored for "testuser"
 assert_no_match "IPv4: username extension (testuser2) → no match" "$PAT_IPV4" "testuser2 pts/0   192.168.1.100    10:00    0.00s 0.01s 0.00s tmux: client"
+# Username suffix → "mytestuser" must not match a pattern for "testuser" (no ^ in old code)
+assert_no_match "IPv4: username suffix (mytestuser) → no match"   "$PAT_IPV4" "mytestuser pts/0   192.168.1.100    10:00    0.00s 0.01s 0.00s tmux: client"
+assert_no_match "IPv6: username suffix (mytestuser) → no match"   "$PAT_IPV6" "mytestuser pts/1    fe80::1          10:00    0.00s 0.01s 0.00s tmux: client"
 
 # --- summary ---
 echo "---"

--- a/tests/unit/shell/w_remote_detection_test.sh
+++ b/tests/unit/shell/w_remote_detection_test.sh
@@ -15,6 +15,7 @@ fail=0
 TESTUSER="testuser"
 PAT_IPV4="^${TESTUSER}([[:space:]]+)([^[:space:]]+)([[:space:]]+)([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})([[:space:]]+)(.+)tmux(.+)"
 PAT_IPV6="^${TESTUSER}([[:space:]]+)([^[:space:]]+)([[:space:]]+)(([0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4})([[:space:]]+)(.+)tmux(.+)"
+PAT_IPV4_MAPPED="^${TESTUSER}([[:space:]]+)([^[:space:]]+)([[:space:]]+)::ffff:([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})([[:space:]]+)(.+)tmux(.+)"
 
 matches_pattern() {
     [[ "$2" =~ $1 ]]
@@ -45,6 +46,7 @@ assert_no_match() {
 # --- test fixtures ---
 
 LINE_IPV4_TMUX="testuser pts/0    192.168.1.100    10:00    0.00s 0.01s 0.00s tmux: client"
+LINE_IPV4_MAPPED_TMUX="testuser pts/0    ::ffff:192.168.1.100 10:00    0.00s 0.01s 0.00s tmux: client"
 LINE_IPV6_TMUX="testuser pts/1    fe80:0:0:1       10:00    0.00s 0.01s 0.00s tmux: client"
 LINE_IPV6_LOOPBACK="testuser pts/2    ::1              10:00    0.00s 0.01s 0.00s tmux: client"
 LINE_IPV6_LINKLOCAL="testuser pts/3    fe80::1          10:00    0.00s 0.01s 0.00s tmux: client"
@@ -58,7 +60,8 @@ LINE_OTHER_USER="otheruser pts/0   192.168.1.100    10:00    0.00s 0.01s 0.00s t
 # --- run tests ---
 
 # IPv4 remote tmux → should match (remote client detected)
-assert_match    "IPv4: remote IP + tmux → match"          "$PAT_IPV4" "$LINE_IPV4_TMUX"
+assert_match    "IPv4: remote IP + tmux → match"                    "$PAT_IPV4"        "$LINE_IPV4_TMUX"
+assert_match    "IPv4-mapped IPv6: ::ffff:x.x.x.x + tmux → match"  "$PAT_IPV4_MAPPED" "$LINE_IPV4_MAPPED_TMUX"
 
 # IPv6 remote tmux → should match (full and compressed forms)
 assert_match    "IPv6: full 4-group + tmux → match"              "$PAT_IPV6" "$LINE_IPV6_TMUX"

--- a/tests/unit/shell/w_remote_detection_test.sh
+++ b/tests/unit/shell/w_remote_detection_test.sh
@@ -14,7 +14,7 @@ fail=0
 # Patterns copied verbatim from src/tmux.c:191-192, prefixed with the test username.
 TESTUSER="testuser"
 PAT_IPV4="${TESTUSER}(.+)([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})(.+)tmux(.+)"
-PAT_IPV6="${TESTUSER}(.+)(([0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4})(.+)tmux(.+)"
+PAT_IPV6="${TESTUSER}([[:space:]]+)([^[:space:]]+)([[:space:]]+)(([0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4})([[:space:]]+)(.+)tmux(.+)"
 
 matches_pattern() {
     [[ "$2" =~ $1 ]]
@@ -50,6 +50,7 @@ LINE_IPV6_LOOPBACK="testuser pts/2    ::1              10:00    0.00s 0.01s 0.00
 LINE_IPV6_LINKLOCAL="testuser pts/3    fe80::1          10:00    0.00s 0.01s 0.00s tmux: client"
 LINE_IPV6_TYPICAL="testuser pts/4    2001:db8::1      10:00    0.00s 0.01s 0.00s tmux: client"
 LINE_LOCAL_TMUX="testuser pts/2    -                10:00    0.00s 0.01s 0.00s tmux: client"
+LINE_LOCAL_TMUX_HHMMSS="testuser pts/2    -                10:00:00 0.00s 0.01s 0.00s tmux: client"
 LINE_IPV4_SSH="testuser pts/3    192.168.1.100    10:00    0.00s 0.01s 0.00s ssh"
 LINE_X11_TMUX="testuser pts/4    :0               10:00    0.00s 0.01s 0.00s tmux: client"
 LINE_OTHER_USER="otheruser pts/0   192.168.1.100    10:00    0.00s 0.01s 0.00s tmux: client"
@@ -66,8 +67,9 @@ assert_match    "IPv6: compressed fe80::1 (link-local) + tmux → match" "$PAT_I
 assert_match    "IPv6: compressed 2001:db8::1 + tmux → match"   "$PAT_IPV6" "$LINE_IPV6_TYPICAL"
 
 # Local login (FROM='-') + tmux → no remote IP, should not match either pattern
-assert_no_match "IPv4: local TTY (FROM=-) + tmux → no match"  "$PAT_IPV4" "$LINE_LOCAL_TMUX"
-assert_no_match "IPv6: local TTY (FROM=-) + tmux → no match"  "$PAT_IPV6" "$LINE_LOCAL_TMUX"
+assert_no_match "IPv4: local TTY (FROM=-) + tmux → no match"           "$PAT_IPV4" "$LINE_LOCAL_TMUX"
+assert_no_match "IPv6: local TTY (FROM=-) + tmux → no match"           "$PAT_IPV6" "$LINE_LOCAL_TMUX"
+assert_no_match "IPv6: local TTY HH:MM:SS idle time → no false match"  "$PAT_IPV6" "$LINE_LOCAL_TMUX_HHMMSS"
 
 # IPv4 address but process is ssh, not tmux → should not match
 assert_no_match "IPv4: remote IP + ssh (not tmux) → no match" "$PAT_IPV4" "$LINE_IPV4_SSH"

--- a/tests/unit/shell/w_remote_detection_test.sh
+++ b/tests/unit/shell/w_remote_detection_test.sh
@@ -14,7 +14,7 @@ fail=0
 # Patterns copied verbatim from src/tmux.c:191-192, prefixed with the test username.
 TESTUSER="testuser"
 PAT_IPV4="^${TESTUSER}([[:space:]]+)([^[:space:]]+)([[:space:]]+)([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})([[:space:]]+)(.+)tmux(.+)"
-PAT_IPV6="^${TESTUSER}([[:space:]]+)([^[:space:]]+)([[:space:]]+)(([0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4})([[:space:]]+)(.+)tmux(.+)"
+PAT_IPV6="^${TESTUSER}([[:space:]]+)([^[:space:]]+)([[:space:]]+)(([0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4})[^[:space:]]*([[:space:]]+)(.+)tmux(.+)"
 PAT_IPV4_MAPPED="^${TESTUSER}([[:space:]]+)([^[:space:]]+)([[:space:]]+)::ffff:([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})([[:space:]]+)(.+)tmux(.+)"
 
 matches_pattern() {
@@ -50,6 +50,7 @@ LINE_IPV4_MAPPED_TMUX="testuser pts/0    ::ffff:192.168.1.100 10:00    0.00s 0.0
 LINE_IPV6_TMUX="testuser pts/1    fe80:0:0:1       10:00    0.00s 0.01s 0.00s tmux: client"
 LINE_IPV6_LOOPBACK="testuser pts/2    ::1              10:00    0.00s 0.01s 0.00s tmux: client"
 LINE_IPV6_LINKLOCAL="testuser pts/3    fe80::1          10:00    0.00s 0.01s 0.00s tmux: client"
+LINE_IPV6_ZONE_INDEX="testuser pts/3    fe80::1%eth0     10:00    0.00s 0.01s 0.00s tmux: client"
 LINE_IPV6_TYPICAL="testuser pts/4    2001:db8::1      10:00    0.00s 0.01s 0.00s tmux: client"
 LINE_LOCAL_TMUX="testuser pts/2    -                10:00    0.00s 0.01s 0.00s tmux: client"
 LINE_LOCAL_TMUX_HHMMSS="testuser pts/2    -                10:00:00 0.00s 0.01s 0.00s tmux: client"
@@ -66,7 +67,8 @@ assert_match    "IPv4-mapped IPv6: ::ffff:x.x.x.x + tmux → match"  "$PAT_IPV4_
 # IPv6 remote tmux → should match (full and compressed forms)
 assert_match    "IPv6: full 4-group + tmux → match"              "$PAT_IPV6" "$LINE_IPV6_TMUX"
 assert_match    "IPv6: compressed ::1 (loopback) + tmux → match" "$PAT_IPV6" "$LINE_IPV6_LOOPBACK"
-assert_match    "IPv6: compressed fe80::1 (link-local) + tmux → match" "$PAT_IPV6" "$LINE_IPV6_LINKLOCAL"
+assert_match    "IPv6: compressed fe80::1 (link-local) + tmux → match"        "$PAT_IPV6" "$LINE_IPV6_LINKLOCAL"
+assert_match    "IPv6: fe80::1%eth0 (zone index) + tmux → match"              "$PAT_IPV6" "$LINE_IPV6_ZONE_INDEX"
 assert_match    "IPv6: compressed 2001:db8::1 + tmux → match"   "$PAT_IPV6" "$LINE_IPV6_TYPICAL"
 
 # Local login (FROM='-') + tmux → no remote IP, should not match either pattern

--- a/tests/unit/shell/w_remote_detection_test.sh
+++ b/tests/unit/shell/w_remote_detection_test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Tests the ERE patterns used by pusb_tmux_has_remote_clients() (src/tmux.c:190-192)
+# to detect remote tmux clients in `w` output.
+#
+# At runtime the C code prepends the escaped username to each pattern via snprintf;
+# we mirror that by prefixing "testuser" to the patterns here.
+# Patterns are exercised with grep -E, which uses the same POSIX ERE engine.
+
+pass=0
+fail=0
+
+# Patterns copied verbatim from src/tmux.c:191-192, prefixed with the test username.
+TESTUSER="testuser"
+PAT_IPV4="${TESTUSER}(.+)([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})(.+)tmux(.+)"
+PAT_IPV6="${TESTUSER}(.+)([0-9A-Fa-f]{1,4}):([0-9A-Fa-f]{1,4}):([0-9A-Fa-f]{1,4}):([0-9A-Fa-f]{1,4})(.+)tmux(.+)"
+
+matches_pattern() {
+    printf '%s\n' "$2" | grep -qE "$1"
+}
+
+assert_match() {
+    local desc="$1" pattern="$2" line="$3"
+    if matches_pattern "$pattern" "$line"; then
+        printf '[PASS] %s\n' "$desc"
+        pass=$((pass + 1))
+    else
+        printf '[FAIL] %s — expected match, got no match\n' "$desc"
+        fail=$((fail + 1))
+    fi
+}
+
+assert_no_match() {
+    local desc="$1" pattern="$2" line="$3"
+    if ! matches_pattern "$pattern" "$line"; then
+        printf '[PASS] %s\n' "$desc"
+        pass=$((pass + 1))
+    else
+        printf '[FAIL] %s — expected no match, got match\n' "$desc"
+        fail=$((fail + 1))
+    fi
+}
+
+# --- test fixtures ---
+
+LINE_IPV4_TMUX="testuser pts/0    192.168.1.100    10:00    0.00s 0.01s 0.00s tmux: client"
+LINE_IPV6_TMUX="testuser pts/1    fe80:0:0:1       10:00    0.00s 0.01s 0.00s tmux: client"
+LINE_LOCAL_TMUX="testuser pts/2    -                10:00    0.00s 0.01s 0.00s tmux: client"
+LINE_IPV4_SSH="testuser pts/3    192.168.1.100    10:00    0.00s 0.01s 0.00s ssh"
+LINE_X11_TMUX="testuser pts/4    :0               10:00    0.00s 0.01s 0.00s tmux: client"
+LINE_OTHER_USER="otheruser pts/0   192.168.1.100    10:00    0.00s 0.01s 0.00s tmux: client"
+
+# --- run tests ---
+
+# IPv4 remote tmux → should match (remote client detected)
+assert_match    "IPv4: remote IP + tmux → match"          "$PAT_IPV4" "$LINE_IPV4_TMUX"
+
+# IPv6 remote tmux → should match
+assert_match    "IPv6: remote IP + tmux → match"          "$PAT_IPV6" "$LINE_IPV6_TMUX"
+
+# Local login (FROM='-') + tmux → no remote IP, should not match either pattern
+assert_no_match "IPv4: local TTY (FROM=-) + tmux → no match"  "$PAT_IPV4" "$LINE_LOCAL_TMUX"
+assert_no_match "IPv6: local TTY (FROM=-) + tmux → no match"  "$PAT_IPV6" "$LINE_LOCAL_TMUX"
+
+# IPv4 address but process is ssh, not tmux → should not match
+assert_no_match "IPv4: remote IP + ssh (not tmux) → no match" "$PAT_IPV4" "$LINE_IPV4_SSH"
+
+# X11 display (:0) + tmux → no valid IP, should not match either pattern
+assert_no_match "IPv4: X11 :0 + tmux → no match"          "$PAT_IPV4" "$LINE_X11_TMUX"
+assert_no_match "IPv6: X11 :0 + tmux → no match"          "$PAT_IPV6" "$LINE_X11_TMUX"
+
+# Different username → pattern starts with "testuser", so a different user should not match
+assert_no_match "IPv4: wrong username → no match"          "$PAT_IPV4" "$LINE_OTHER_USER"
+
+# --- summary ---
+echo "---"
+printf '%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/tests/unit/shell/w_remote_detection_test.sh
+++ b/tests/unit/shell/w_remote_detection_test.sh
@@ -13,7 +13,7 @@ fail=0
 
 # Patterns copied verbatim from src/tmux.c:191-192, prefixed with the test username.
 TESTUSER="testuser"
-PAT_IPV4="${TESTUSER}(.+)([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})(.+)tmux(.+)"
+PAT_IPV4="${TESTUSER}([[:space:]]+)([^[:space:]]+)([[:space:]]+)([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})([[:space:]]+)(.+)tmux(.+)"
 PAT_IPV6="${TESTUSER}([[:space:]]+)([^[:space:]]+)([[:space:]]+)(([0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4})([[:space:]]+)(.+)tmux(.+)"
 
 matches_pattern() {
@@ -80,6 +80,8 @@ assert_no_match "IPv6: X11 :0 + tmux → no match"          "$PAT_IPV6" "$LINE_X
 
 # Different username → pattern starts with "testuser", so a different user should not match
 assert_no_match "IPv4: wrong username → no match"          "$PAT_IPV4" "$LINE_OTHER_USER"
+# Username extension → "testuser2" must not match a pattern anchored for "testuser"
+assert_no_match "IPv4: username extension (testuser2) → no match" "$PAT_IPV4" "testuser2 pts/0   192.168.1.100    10:00    0.00s 0.01s 0.00s tmux: client"
 
 # --- summary ---
 echo "---"

--- a/tests/unit/shell/w_remote_detection_test.sh
+++ b/tests/unit/shell/w_remote_detection_test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+export LC_ALL=C
 # Tests the ERE patterns used by pusb_tmux_has_remote_clients() (src/tmux.c:190-192)
 # to detect remote tmux clients in `w` output.
 #


### PR DESCRIPTION
## Summary

- Adds \`set -euo pipefail\` + \`export LC_ALL=C\` to \`loginctl_session_id_test.sh\`; rewrites \`extract_with_guard\` with \`if/fi\` so an empty session ID doesn't produce a non-zero exit under strict mode
- Replaces \`printf|awk\` and \`printf|sed -n ...;q\` pipelines with pure-Bash \`[[ =~ ]]\` / parameter expansion to eliminate SIGPIPE risk under \`pipefail\`
- Adds \`extract_property_value()\` helper + 4 new cases covering the \`awk -F= '{print $2}'\` pipeline in \`pusb_get_loginctl_session_property()\`
- Adds \`tests/unit/shell/w_remote_detection_test.sh\` (new, \`set -euo pipefail\`, \`LC_ALL=C\`) with 17 cases for the IPv4/IPv6/IPv4-mapped ERE patterns in \`pusb_tmux_has_remote_clients()\` (\`src/tmux.c\`), wired into \`make test-shell\`

Seven security/correctness bugs in \`src/tmux.c\` were uncovered while writing the tests, plus additional fixes found in review. Two of the pre-existing bugs qualify as new security advisories:

- **[GHSA-gc4c-v52c-2v34](https://github.com/mcdope/pam_usb/security/advisories/GHSA-gc4c-v52c-2v34)** (HIGH, 7.4) — Compressed IPv6 bypass: \`::1\`, \`fe80::1\`, \`2001:db8::1\` and any other compressed IPv6 address bypassed \`deny_remote\` entirely. The old pattern required four explicit 4-hex-digit groups.
- **[GHSA-7583-9cqv-j9rf](https://github.com/mcdope/pam_usb/security/advisories/GHSA-7583-9cqv-j9rf)** (HIGH, 7.4) — Zone index bypass: link-local addresses with a zone index (\`fe80::1%eth0\`) were not matched because the \`%ifname\` suffix appeared before the expected whitespace field separator.

Full list of fixes in this PR:

- **Compressed IPv6 bypass** (GHSA-gc4c-v52c-2v34) — fixed with \`(([0-9A-Fa-f]{0,4}:){2,7}[0-9A-Fa-f]{0,4})\`.
- **Zone index bypass** (GHSA-7583-9cqv-j9rf) — fixed with \`[^[:space:]]*\` after the address group.
- **IPv4-mapped IPv6 bypass** (already tracked: GHSA-jmmj-qhrq-w45g) — third regex template added for \`::ffff:x.x.x.x\`.
- **HH:MM:SS false positive** — \`(.+)\` before address groups spanned field boundaries; anchored to FROM column with \`([[:space:]]+)([^[:space:]]+)([[:space:]]+)\`.
- **IPv4 username-prefix false positive** — same \`(.+)\` prefix allowed \`testuser\` to match \`testuser2\` session.
- **Username suffix bypass** — without \`^\`, pattern for \`testuser\` matched \`mytestuser\` as substring.
- **\`regfree\` on uninitialized \`regex_t\`** — UB on failed \`regcomp\`; removed from failure path.
- **File-descriptor leak** — \`popen "r"\` changed to \`"re"\` for \`O_CLOEXEC\`.
- **Triple \`popen\` on auth path** — all three regexes compiled upfront, \`popen\` called exactly once.
- **NULL username segfault** — early return -1 guard added.
- **escaped_username buffer too small for SSSD/AD** — expanded from 65 to 512 bytes.
- **Username truncation bypass** — \`strlen > 255\` guard returning -1 before escape step.
- **Incorrect \`pclose\` failure check** — \`== -1\` instead of non-zero.
- **Fail-open when \`w\` exits non-zero** — \`pclose != 0 && result == 0\` now sets result = -1 (deny).

Additional hardening: \`w -i\` forces numeric IP output; \`REG_NOSUB\` added; DevSkim DS140021 suppressed on \`strlen\` (false positive).

## Approach

The two pipelines identified in #419 have no structural barrier to silent breakage — a stray \`loginctl\` format change or a regex edit in \`tmux.c\` would go undetected by the existing suite. The new tests mirror the exact patterns used at runtime so any divergence is immediately visible.

All seven original \`src/tmux.c\` security bugs were found as a direct result of writing the shell-level tests: exercising the regex patterns in isolation made each defect obvious in a way that wasn't apparent from reading the C code alone.

## Test plan

- [x] \`make test-shell\` — 12 passed / 0 failed (loginctl), 17 passed / 0 failed (w-regex)
- [x] \`make test-c-tmux\` — 38 passed / 0 failed
- [x] \`make test\` — full suite (C + Python + shell) passes

Closes #419

🤖 This PR was generated with the assistance of Claude Sonnet 4.6

I have read the rules