### PR TITLE
Clarify exclusion of automated bounty-hunting tools from security bounty

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Please fork the repository, implement your changes in a branch, and then submit 
 
 *If you are using AI tools (e.g., Claude, Codex, Cursor, Aider) to write code for your PR, you **must** adhere to the following additional rules:*
 
-* **No Autonomous Bots:** Fully automated agents that scrape issues and open PRs without human oversight are strictly forbidden. A human **must** review, understand, and take responsibility for every line of code submitted. Drive-by bot PRs will be marked as spam and closed immediately. GitHub account activity is reviewed as part of PR evaluation — accounts that show signs of automation or that were created specifically to submit PRs will not be accepted.
+* **No Autonomous Bots:** Fully automated agents that scrape issues and open PRs without human oversight are strictly forbidden. This includes automated bounty-hunting tools and services (e.g., TaskBounty) — these are **never** eligible for the security bounty, regardless of the quality of the submission. A human **must** review, understand, and take responsibility for every line of code submitted. Drive-by bot PRs will be marked as spam and closed immediately. GitHub account activity is reviewed as part of PR evaluation — accounts that show signs of automation or that were created specifically to submit PRs will not be accepted.
 * **Commit Attribution:** AI-assisted commits **must** include a `Co-authored-by` trailer at the very end of the commit message (e.g., `Co-authored-by: NameOfAI <email@example.com>`). Ensure there is a blank line separating the main message body from the trailer so Git and platforms like GitHub parse it correctly.
 * **PR Descriptions (Tagging):** Add a note in the PR description indicating that an AI coding agent assisted with the PR (e.g., `🤖 This PR was generated with the assistance of [AI Name]`).
 * **Proof of Execution:** AI contributions **must** provide verifiable proof that **all** tests passed — unit tests (`make test`) **and** the full functional suite (`tests/can-actually-be-used/run-tests.sh`). Acceptable proof: a screenshot of a successful manual run, or a link to your own GitHub Actions CI job where all tests succeeded. Running only `make test` without the functional suite is **not** sufficient.
@@ -91,6 +91,7 @@ Your PR is **not bounty-eligible** if any of the following apply:
 * You violated **any** point outlined in this document.
 * Your GitHub activity indicates a fully automated account, or the account was created
   specifically to submit this PR.
+* The PR was submitted by, or primarily authored by, an automated bounty-hunting tool or service (e.g., TaskBounty). Bounties exist to reward genuine contributor effort — not automated pipelines scraping issues for reward opportunities.
 * The contribution is considered **trivial or low-impact**:
   * Minor changes touching only a handful of lines.
   * Security fixes for vulnerabilities scoring below **Critical** on the CVSS scale.


### PR DESCRIPTION
## Summary

- Expands the **No Autonomous Bots** bullet in the AI-Assisted Contributions section to explicitly name automated bounty-hunting tools and services (e.g., TaskBounty) and state they are never eligible for the security bounty
- Adds a matching exclusion bullet to the **Security Bounty** ineligibility list making it unambiguous that automated pipelines scraping issues for reward opportunities are excluded

## Approach

Pure documentation change — no code touched. The existing language already prohibited "fully automated agents" but did not name bounty-hunting tools or explicitly connect that prohibition to bounty eligibility. The additions close that gap without changing any other rules.

Closes #424

🤖 This PR was generated with the assistance of Claude Sonnet 4.6

I have read the rules