### PR TITLE
[Bug] Fix make deinstall leaving PAM config behind due to wrong path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,13 +266,12 @@ deinstall:
 		$(TOOLS_DEST)/$(PAMUSB_AGENT) \
 		$(TOOLS_DEST)/$(PAMUSB_KEYRING_GNOME) \
 		$(TOOLS_DEST)/$(PAMUSB_PINENTRY) \
-		$(PAM_CONF_DEST)/$(PAM_CONF) \
+		$(PAM_CONF_DEST)/libpam-usb \
 		$(POLKIT_CONF_DEST)/systemd-polkit-agent-helper-pamusb.conf
 
 	$(RM) -rf $(DOCS_DEST)
 	$(RM) -f $(addprefix $(MANS_DEST)/,$(notdir $(MANS)))
 	$(RM) -f $(MANS_DEST)/pamusb-*\.1\.gz
-	$(RM) -f $(PAM_CONF_DEST)/$(PAM_CONF)
 
 uninstall: deinstall
 


### PR DESCRIPTION
## Summary

- `$(PAM_CONF_DEST)/$(PAM_CONF)` in the `deinstall` target expanded to the **source** path (`/usr/share/pam-configs/debian/pam-auth-update/usb`) instead of the **installed** path (`/usr/share/pam-configs/libpam-usb`), so `make deinstall` silently left the PAM config behind.
- The wrong removal appeared **twice** (lines 265 and 271 in the pre-fix Makefile); the duplicate line is also removed.

## Why this approach

The install target uses a hardcoded destination name (`libpam-usb`) rather than deriving it from `$(PAM_CONF)`, so the deinstall target must use the same hardcoded name. Using `$(PAM_CONF_DEST)/libpam-usb` exactly mirrors what `install` writes.

## Test plan

- [x] `make install` → `/usr/share/pam-configs/libpam-usb` exists
- [x] `make deinstall` → file is gone, no error printed
- [x] `make test` → no regressions (Makefile-only change)

Closes #422

🤖 This PR was generated with the assistance of Claude Sonnet 4.6

I have read the rules