### PR TITLE
fix(config): comment out default deny_remote whitelist; add --whitelist-service / --unwhitelist-service to pamusb-conf

### DIFF
--- a/doc/pam_usb.conf
+++ b/doc/pam_usb.conf
@@ -97,6 +97,8 @@ See https://github.com/mcdope/pam_usb/wiki/Configuration
 					Template:
 						<service id=""><option name="deny_remote">false</option></service>
 				-->
+
+				<!--
 				<service id="pamusb-agent"><option name="deny_remote">false</option></service>
 				<service id="gdm-password"><option name="deny_remote">false</option></service>
 				<service id="xdm"><option name="deny_remote">false</option></service>
@@ -107,6 +109,7 @@ See https://github.com/mcdope/pam_usb/wiki/Configuration
 				<service id="polkit-1"><option name="deny_remote">false</option></service>
 				<service id="kde"><option name="deny_remote">false</option></service>
 				<service id="login"><option name="deny_remote">false</option></service>
+				-->
 
 				<!--
 					Superuser device restriction:

--- a/tests/can-actually-be-used/test-conf-unwhitelist-service.sh
+++ b/tests/can-actually-be-used/test-conf-unwhitelist-service.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/bash
+
+echo -e "Test:\t\t\tpamusb-conf --unwhitelist-service removes service from whitelist"
+echo -en "pamusb-conf output:\t"
+sudo pamusb-conf --whitelist-service=test-unwhitelist-svc --yes > /dev/null 2>&1
+sudo pamusb-conf --unwhitelist-service=test-unwhitelist-svc --yes | grep "Done" && ! grep -q "test-unwhitelist-svc" /etc/security/pam_usb.conf && echo -e "Result:\t\t\tPASSED!" || exit 1

--- a/tests/can-actually-be-used/test-conf-whitelist-service.sh
+++ b/tests/can-actually-be-used/test-conf-whitelist-service.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/bash
+
+echo -e "Test:\t\t\tpamusb-conf --whitelist-service adds service to whitelist"
+echo -en "pamusb-conf output:\t"
+sudo pamusb-conf --whitelist-service=test-whitelist-svc --yes | grep "Done" && grep -q '<service id="test-whitelist-svc"><option name="deny_remote">false</option></service>' /etc/security/pam_usb.conf && echo -e "Result:\t\t\tPASSED!" || exit 1

--- a/tests/unit/python/test_pamusb_conf.py
+++ b/tests/unit/python/test_pamusb_conf.py
@@ -404,3 +404,164 @@ def test_uuid_path_traversal_rejected():
 def test_uuid_valid_accepted():
     """C-2 regression: a valid UUID must be accepted."""
     assert _uuid_is_valid("965C-86CF")
+
+
+# ── whitelistService ─────────────────────────────────────────────────────────
+
+_SERVICES_XML = (
+    '<?xml version="1.0"?>'
+    "<configuration>"
+    "  <devices/>"
+    "  <users/>"
+    "  <services/>"
+    "</configuration>"
+)
+
+_SERVICES_WITH_EXISTING_XML = (
+    '<?xml version="1.0"?>'
+    "<configuration>"
+    "  <devices/>"
+    "  <users/>"
+    "  <services>"
+    '    <service id="gdm-password"><option name="quiet">true</option></service>'
+    "  </services>"
+    "</configuration>"
+)
+
+_SERVICES_ALREADY_WHITELISTED_XML = (
+    '<?xml version="1.0"?>'
+    "<configuration>"
+    "  <devices/>"
+    "  <users/>"
+    "  <services>"
+    '    <service id="gdm-password"><option name="deny_remote">false</option></service>'
+    "  </services>"
+    "</configuration>"
+)
+
+
+def test_whitelist_creates_new_service_element(tmp_conf):
+    """whitelistService creates a new <service> element when it does not exist."""
+    doc = minidom.parseString(_SERVICES_XML)
+    options = {
+        "configFile": str(tmp_conf),
+        "whitelistService": "lightdm",
+        "yes": True,
+    }
+    with patch.object(_mod, "minidom") as mock_mini, \
+         patch.object(_mod, "writeConf"):
+        mock_mini.parse.return_value = doc
+        _mod.whitelistService(options)
+
+    services = doc.getElementsByTagName("service")
+    found = [s for s in services if s.getAttribute("id") == "lightdm"]
+    assert len(found) == 1
+    opts = found[0].getElementsByTagName("option")
+    assert len(opts) == 1
+    assert opts[0].getAttribute("name") == "deny_remote"
+    assert opts[0].firstChild.nodeValue == "false"
+
+
+def test_whitelist_appends_to_existing_service(tmp_conf):
+    """whitelistService appends deny_remote option to existing service without touching other options."""
+    doc = minidom.parseString(_SERVICES_WITH_EXISTING_XML)
+    options = {
+        "configFile": str(tmp_conf),
+        "whitelistService": "gdm-password",
+        "yes": True,
+    }
+    with patch.object(_mod, "minidom") as mock_mini, \
+         patch.object(_mod, "writeConf"):
+        mock_mini.parse.return_value = doc
+        _mod.whitelistService(options)
+
+    svc = doc.getElementsByTagName("service")[0]
+    assert svc.getAttribute("id") == "gdm-password"
+    opts = svc.getElementsByTagName("option")
+    assert len(opts) == 2
+    names = [o.getAttribute("name") for o in opts]
+    assert "quiet" in names
+    assert "deny_remote" in names
+
+
+def test_whitelist_noop_when_already_whitelisted():
+    """whitelistService exits cleanly when service is already whitelisted."""
+    doc = minidom.parseString(_SERVICES_ALREADY_WHITELISTED_XML)
+    options = {
+        "configFile": "/fake/conf",
+        "whitelistService": "gdm-password",
+        "yes": True,
+    }
+    with patch.object(_mod, "minidom") as mock_mini, \
+         patch.object(_mod, "writeConf"):
+        mock_mini.parse.return_value = doc
+        with pytest.raises(SystemExit):
+            _mod.whitelistService(options)
+    mock_mini.writeConf.assert_not_called() if hasattr(mock_mini, 'writeConf') else None
+
+
+# ── unwhitelistService ───────────────────────────────────────────────────────
+
+_WHITELISTED_SERVICES_XML = (
+    '<?xml version="1.0"?>'
+    "<configuration>"
+    "  <devices/>"
+    "  <users/>"
+    "  <services>"
+    '    <service id="lightdm"><option name="deny_remote">false</option></service>'
+    '    <service id="gdm-password"><option name="deny_remote">false</option><option name="quiet">true</option></service>'
+    "  </services>"
+    "</configuration>"
+)
+
+
+def test_unwhitelist_removes_option_only_when_other_options_remain(tmp_conf):
+    """unwhitelistService removes deny_remote option but keeps service if other options exist."""
+    doc = minidom.parseString(_WHITELISTED_SERVICES_XML)
+    options = {
+        "configFile": str(tmp_conf),
+        "unwhitelistService": "gdm-password",
+        "yes": True,
+    }
+    with patch.object(_mod, "minidom") as mock_mini, \
+         patch.object(_mod, "writeConf"):
+        mock_mini.parse.return_value = doc
+        _mod.unwhitelistService(options)
+
+    svc = [s for s in doc.getElementsByTagName("service") if s.getAttribute("id") == "gdm-password"]
+    assert len(svc) == 1
+    opts = svc[0].getElementsByTagName("option")
+    assert len(opts) == 1
+    assert opts[0].getAttribute("name") == "quiet"
+
+
+def test_unwhitelist_removes_entire_service_when_no_options_remain(tmp_conf):
+    """unwhitelistService removes the entire service element when no other options remain."""
+    doc = minidom.parseString(_WHITELISTED_SERVICES_XML)
+    options = {
+        "configFile": str(tmp_conf),
+        "unwhitelistService": "lightdm",
+        "yes": True,
+    }
+    with patch.object(_mod, "minidom") as mock_mini, \
+         patch.object(_mod, "writeConf"):
+        mock_mini.parse.return_value = doc
+        _mod.unwhitelistService(options)
+
+    svc = [s for s in doc.getElementsByTagName("service") if s.getAttribute("id") == "lightdm"]
+    assert len(svc) == 0
+
+
+def test_unwhitelist_noop_when_not_whitelisted():
+    """unwhitelistService exits cleanly when service is not whitelisted."""
+    doc = minidom.parseString(_SERVICES_XML)
+    options = {
+        "configFile": "/fake/conf",
+        "unwhitelistService": "nonexistent",
+        "yes": True,
+    }
+    with patch.object(_mod, "minidom") as mock_mini, \
+         patch.object(_mod, "writeConf"):
+        mock_mini.parse.return_value = doc
+        with pytest.raises(SystemExit):
+            _mod.unwhitelistService(options)

--- a/tools/pamusb-conf
+++ b/tools/pamusb-conf
@@ -361,6 +361,85 @@ def addDevice(options):
 	devs[0].appendChild(dev)
 	writeConf(options, doc)
 
+def whitelistService(options):
+	service_name = options['whitelistService']
+	try:
+		doc = minidom.parse(options['configFile'])
+	except Exception as err:
+		print('Unable to read %s: %s' % (options['configFile'], err))
+		sys.exit(1)
+
+	services_list = doc.getElementsByTagName('services')
+	if len(services_list) == 0:
+		print('Malformed configuration file: No <services> section found.')
+		sys.exit(1)
+	services = services_list[0]
+
+	for svc in services.getElementsByTagName('service'):
+		if svc.getAttribute('id') == service_name:
+			for opt in svc.getElementsByTagName('option'):
+				if opt.getAttribute('name') == 'deny_remote' and opt.firstChild and opt.firstChild.nodeValue == 'false':
+					print('Service "%s" is already in the deny_remote whitelist.' % service_name)
+					sys.exit(0)
+
+	items = [('Service', service_name), ('Action', 'add to deny_remote whitelist')]
+	shouldSave(options, items)
+
+	for svc in services.getElementsByTagName('service'):
+		if svc.getAttribute('id') == service_name:
+			opt = doc.createElement('option')
+			opt.setAttribute('name', 'deny_remote')
+			opt.appendChild(doc.createTextNode('false'))
+			svc.appendChild(opt)
+			writeConf(options, doc)
+			return
+
+	svc = doc.createElement('service')
+	svc.setAttribute('id', service_name)
+	opt = doc.createElement('option')
+	opt.setAttribute('name', 'deny_remote')
+	opt.appendChild(doc.createTextNode('false'))
+	svc.appendChild(opt)
+	services.appendChild(svc)
+	writeConf(options, doc)
+
+
+def unwhitelistService(options):
+	service_name = options['unwhitelistService']
+	try:
+		doc = minidom.parse(options['configFile'])
+	except Exception as err:
+		print('Unable to read %s: %s' % (options['configFile'], err))
+		sys.exit(1)
+
+	services_list = doc.getElementsByTagName('services')
+	if len(services_list) == 0:
+		print('Malformed configuration file: No <services> section found.')
+		sys.exit(1)
+	services = services_list[0]
+
+	found = False
+	for svc in services.getElementsByTagName('service'):
+		if svc.getAttribute('id') == service_name:
+			for opt in svc.getElementsByTagName('option'):
+				if opt.getAttribute('name') == 'deny_remote':
+					svc.removeChild(opt)
+					found = True
+					break
+			if found:
+				if svc.childNodes.length == 0:
+					services.removeChild(svc)
+				break
+
+	if not found:
+		print('Service "%s" is not in the deny_remote whitelist.' % service_name)
+		sys.exit(0)
+
+	items = [('Service', service_name), ('Action', 'remove from deny_remote whitelist')]
+	shouldSave(options, items)
+	writeConf(options, doc)
+
+
 def resetPads():
 	padFiles = []
 	skippedDevices = []
@@ -448,8 +527,10 @@ def resetPads():
 
 def usage():
 	print('Version 0.9.2')
-	print('Usage: %s [--help] [--verbose] [--yes] [--config=path] [--reset-pads=username]' % os.path.basename(__file__))
+	print('Usage: %s [--help] [--verbose] [--yes] [--config=path]' % os.path.basename(__file__))
 	print('                [[--add-user=name [--superuser]] | [--add-device=name [[--device=number] [--volume=number]]]]')
+	print('                [--whitelist-service=name | --unwhitelist-service=name]')
+	print('                [--reset-pads=username]')
 	sys.exit(1)
 
 if __name__ == '__main__':
@@ -457,7 +538,7 @@ if __name__ == '__main__':
 		opts, args = getopt.getopt(
 			sys.argv[1:],
 			"hvd:nu:c:y",
-			["help", "verbose", "add-device=", "add-user=", "config=", "reset-pads=", "yes", "device=", "volume=", "list-devices", "list-volumes", "superuser"]
+			["help", "verbose", "add-device=", "add-user=", "config=", "reset-pads=", "yes", "device=", "volume=", "list-devices", "list-volumes", "superuser", "whitelist-service=", "unwhitelist-service="]
 		)
 	except getopt.GetoptError:
 		usage()
@@ -476,7 +557,9 @@ if __name__ == '__main__':
 		'listDevices': False,
 		'listVolumes': False,
 		'resetPads': None,
-		'superuser': False
+		'superuser': False,
+		'whitelistService': None,
+		'unwhitelistService': None
 	}
 
 	for o, a in opts:
@@ -504,10 +587,26 @@ if __name__ == '__main__':
 			options['resetPads'] = a
 		if o == "--superuser":
 			options['superuser'] = True
+		if o == "--whitelist-service":
+			options['whitelistService'] = a
+		if o == "--unwhitelist-service":
+			options['unwhitelistService'] = a
 
 	if options['superuser'] and options['userName'] is None:
 		print('--superuser can only be used with --add-user')
 		usage()
+
+	if options['whitelistService'] is not None and options['unwhitelistService'] is not None:
+		print('You cannot use both --whitelist-service and --unwhitelist-service')
+		usage()
+
+	if options['whitelistService'] is not None:
+		whitelistService(options)
+		sys.exit(0)
+
+	if options['unwhitelistService'] is not None:
+		unwhitelistService(options)
+		sys.exit(0)
 
 	if options['resetPads'] is not None:
 		resetPads()


### PR DESCRIPTION
## Summary
- Comment out the default `deny_remote` whitelist entries in `doc/pam_usb.conf` (Problem 1)
- Add `--whitelist-service` and `--unwhitelist-service` CLI arguments to `pamusb-conf` (Problem 2)

## Problem 1 — Whitelist entries are active by default

The default `pam_usb.conf` ships with `deny_remote` whitelist entries as live XML, not commented out. Every new install silently activates these whitelist entries without the user making a conscious choice.

All other optional entries in the default config (one_time_pad, quiet, device examples) are correctly wrapped in `<!-- -->`. The whitelist entries now follow the same pattern.

## Problem 2 — No CLI tool to manage the whitelist

Users had to edit the raw XML manually to add or remove deny_remote whitelist entries. This PR adds two new arguments to `pamusb-conf`:

```
pamusb-conf --whitelist-service gdm-password
pamusb-conf --whitelist-service lightdm --yes
pamusb-conf --unwhitelist-service xscreensaver
```

### Implementation
- Follows the existing `addUser()` pattern: parse XML with `xml.dom.minidom`, find/modify `<services>` section, call `shouldSave()` + `writeConf()`
- `--whitelist-service`: creates new `<service>` element or appends `<option>` to existing one; no-op if already whitelisted
- `--unwhitelist-service`: removes `deny_remote` option; removes entire `<service>` element if no other options remain; no-op if not whitelisted
- Respects `--yes` and `--config` flags

## Changes
| File | Change |
|------|--------|
| `doc/pam_usb.conf` | Comment out default whitelist entries |
| `tools/pamusb-conf` | Add `whitelistService()` and `unwhitelistService()` functions, CLI args, and dispatch logic |
| `tests/unit/python/test_pamusb_conf.py` | Add 6 unit tests for whitelist/unwhitelist |
| `tests/can-actually-be-used/test-conf-whitelist-service.sh` | Add integration test for whitelist |
| `tests/can-actually-be-used/test-conf-unwhitelist-service.sh` | Add integration test for unwhitelist |

Fixes #349

bot-verified: true