### PR TITLE
Security audit (round 8): deny_remote NUL-termination + 3 correctness/UB fixes

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -274,8 +274,8 @@ int pusb_conf_parse(
 	}
 	for (int i = 0; i < n_devices; i++)
 	{
-		device_list[i] = xmalloc(128);
-		memset(device_list[i], 0x0, 128);
+		device_list[i] = xmalloc(sizeof(opts->device.name));
+		memset(device_list[i], 0x0, sizeof(opts->device.name));
 	}
 
 	opts->device_list = xmalloc(n_devices * sizeof(t_pusb_device));
@@ -349,8 +349,8 @@ int pusb_conf_parse(
 		}
 		for (int i = 0; i < n_devices; i++)
 		{
-			su_names[i] = xmalloc(128);
-			memset(su_names[i], 0, 128);
+			su_names[i] = xmalloc(sizeof(opts->device.name));
+			memset(su_names[i], 0, sizeof(opts->device.name));
 		}
 
 		if (pusb_xpath_get_string_list(doc, su_xpath, su_names, sizeof(opts->device.name), n_devices))

--- a/src/local.c
+++ b/src/local.c
@@ -80,6 +80,11 @@ int pusb_is_tty_local(char *tty)
 	struct utmpx utsearch;
 	struct utmpx *utent;
 
+	if (tty == NULL)
+	{
+		return (0);
+	}
+
 	if (strncmp(tty, "/dev/", 5) == 0)
 	{
 		tty += 5; // cut leading "/dev/"

--- a/src/local.c
+++ b/src/local.c
@@ -80,9 +80,9 @@ int pusb_is_tty_local(char *tty)
 	struct utmpx utsearch;
 	struct utmpx *utent;
 
-	if (strstr(tty, "/dev/") != NULL) 
+	if (strncmp(tty, "/dev/", 5) == 0)
 	{
-		tty += 5; // cut "/dev/"
+		tty += 5; // cut leading "/dev/"
 	}
 
 	snprintf(utsearch.ut_line, sizeof(utsearch.ut_line), "%s", tty);

--- a/src/process.c
+++ b/src/process.c
@@ -42,6 +42,16 @@
  */
 void pusb_get_process_name(const pid_t pid, char *name, size_t name_len)
 {
+	if (name == NULL || name_len == 0)
+		return;
+
+	/* Guarantee a valid, NUL-terminated string on every path. If the process
+	 * has already exited (fopen fails), the caller must not be left scanning
+	 * uninitialized or stale buffer contents: pusb_local_login() feeds this
+	 * result straight into strstr() while walking the process ancestry, so a
+	 * non-terminated buffer there is both UB and a fail-open in deny_remote. */
+	name[0] = '\0';
+
 	char procfile[BUFSIZ];
 	snprintf(procfile, sizeof(procfile), "/proc/%d/cmdline", pid);
 	FILE* f = fopen(procfile, "re"); /* DevSkim: ignore DS154189 - path constructed from numeric PID only */

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -302,12 +302,12 @@ int pusb_xpath_get_time(xmlDocPtr doc, const char *path, time_t *value)
 	{
 		coef = 3600 * 24;
 	}
-	else if (!isdigit(*last))
+	else if (!isdigit((unsigned char)*last))
 	{
 		log_debug("Expecting a time modifier, got %c\n", *last);
 		return 0;
 	}
-	if (!isdigit(*last))
+	if (!isdigit((unsigned char)*last))
 	{
 		*last = '\0';
 	}

--- a/tests/unit/c/local_test.c
+++ b/tests/unit/c/local_test.c
@@ -214,6 +214,13 @@ static void test_read_cmdline_read_error(void **state)
 	assert_int_equal(-1, n);
 }
 
+static void test_is_tty_local_null_returns_zero(void **state)
+{
+	(void)state;
+	/* NULL tty must be rejected safely (fail-closed), never dereferenced. */
+	assert_int_equal(0, pusb_is_tty_local(NULL));
+}
+
 static void test_local_login_denies_xrdp_session(void **state)
 {
 	(void)state;
@@ -306,6 +313,7 @@ int main(void)
 		cmocka_unit_test(test_loginctl_parse_output_valid_with_newline),
 		cmocka_unit_test(test_loginctl_parse_output_valid_without_newline),
 		cmocka_unit_test(test_loginctl_cmd_uses_auto_not_user_status),
+		cmocka_unit_test(test_is_tty_local_null_returns_zero),
 		cmocka_unit_test(test_local_login_denies_xrdp_session),
 		cmocka_unit_test(test_local_login_display_env_null),
 		cmocka_unit_test(test_local_login_display_env_set),

--- a/tests/unit/c/process_test.c
+++ b/tests/unit/c/process_test.c
@@ -38,10 +38,15 @@ static void test_process_name_pid1(void **state)
 static void test_process_name_invalid_pid(void **state)
 {
 	(void)state;
-	char name[256] = {0};
-	/* Should not crash on a non-existent PID; name remains empty */
+	/* Fill with a non-NUL sentinel so we prove the function terminates the
+	 * buffer itself instead of relying on the caller having pre-zeroed it.
+	 * /proc/-1/cmdline cannot be opened, which exercises the fopen-failure
+	 * path the real caller (pusb_local_login) hits when an ancestor process
+	 * exits mid-walk — there the buffer is uninitialised stack. */
+	char name[256];
+	memset(name, 'A', sizeof(name));
 	pusb_get_process_name(-1, name, sizeof(name));
-	/* No assertion on value — just confirm no crash */
+	assert_int_equal('\0', name[0]);
 }
 
 /* ── pusb_get_process_parent_id ── */

--- a/tests/unit/c/xpath_test.c
+++ b/tests/unit/c/xpath_test.c
@@ -154,6 +154,21 @@ static void test_time_empty_numeric_part(void **state)
 	xmlFreeDoc(doc);
 }
 
+static void test_time_non_ascii_suffix(void **state)
+{
+	(void)state;
+	/* A trailing byte with the high bit set (here the UTF-8 'é', last byte
+	 * 0xA9) must be rejected as an invalid modifier, never passed to isdigit()
+	 * as a negative int (UB, CERT STR37-C). Pins the (unsigned char) cast in
+	 * pusb_xpath_get_time; on glibc the value is rejected either way, so this
+	 * is a portability/UB-hardening pin rather than a behavioural red/green. */
+	xmlDocPtr doc = make_doc("<r><v>30\xc3\xa9</v></r>");
+	time_t val = 999;
+	assert_int_equal(0, pusb_xpath_get_time(doc, "//r/v", &val));
+	assert_true(val == 999);
+	xmlFreeDoc(doc);
+}
+
 /* ── pusb_xpath_get_int ── */
 
 static void test_int_value(void **state)
@@ -333,6 +348,7 @@ int main(void)
 		cmocka_unit_test(test_time_overflow),
 		cmocka_unit_test(test_time_overflow_via_multiplication),
 		cmocka_unit_test(test_time_empty_numeric_part),
+		cmocka_unit_test(test_time_non_ascii_suffix),
 		cmocka_unit_test(test_int_value),
 		cmocka_unit_test(test_int_zero),
 		cmocka_unit_test(test_int_overflow),


### PR DESCRIPTION
## Summary

Round-8 security audit (assisted by an AI coding agent, Claude Opus 4.8). Method: ASAN+UBSAN dynamic run over the full C unit suite plus a file-by-file review of `src/*.c`. The codebase is already well-hardened across the prior rounds; this PR lands the one real defect found plus three minor correctness/robustness fixes, as four atomic commits.

## Why these changes

- **[Bug] `pusb_get_process_name` NUL-termination** — the function wrote the caller's buffer only on `fopen` success. The `deny_remote` ancestry walk in `pusb_local_login()` passes an *uninitialised* `char[BUFSIZ]` and feeds the result straight to `strstr(name, "sshd"/…)`. A process exiting mid-walk (or `EMFILE` / `hidepid` / an LSM denial) leaves the scan reading uninitialised or stale stack — undefined behaviour, and the failure direction is **fail-open** for the remote-access check. This is the security-relevant fix. Severity Low–Medium (the `fopen` failure is not reliably attacker-triggerable), hence no advisory. The existing unit test masked the bug by pre-zeroing the buffer; it now proves termination (red against the old code, green after).
- **[Bug] `isdigit()` signed-char cast in `pusb_xpath_get_time`** — passing a `char` ≥ 0x80 to `isdigit()` is UB (CERT STR37-C); the same file already casts elsewhere. glibc-benign; UB-hardening plus path coverage under UBSAN.
- **[Bug] `/dev/` prefix strip in `pusb_is_tty_local`** — `strstr` presence + a fixed `+5` mis-strips inputs where `/dev/` is not the leading prefix; now a real `strncmp` prefix check. The previous misparse failed closed.
- **[Refactor] `sizeof` for pad-name scratch buffers** — replaces a magic `128` that is coupled to `sizeof(t_pusb_device.name)`. No live overflow today; prevents silent drift if the struct changes.

## Security rationale

Commit 1 touches the `deny_remote` control directly: it removes an undefined-behaviour read and closes a fail-open path where a transient `/proc` read failure could cause a remote-daemon ancestor to be missed during the process-ancestry walk. Per the disclosure policy, no attack walkthrough is included. The remaining commits are defensive/UB hardening in config parsing and tty handling.

## Out of scope — seccomp/privsep worker (evaluated, declined)

A whitelist-seccomp worker banning `open`/`socket`/`execve` is incompatible with this module: it requires `socket` (UDisks2 DBus), `open` (config, OTP pads, `/proc`, `/dev/input`) and `execve` (`popen` of `loginctl`/`tmux`/`w`). PAM modules also load into threaded hosts (e.g. gdm) where `fork()` is unsafe with glib/UDisks state. The existing setgid `pamusb-evdev-helper` is the correct, already-applied privsep boundary, so no change is proposed here.

## Testing

- `make test-c` under `-fsanitize=address,undefined -U_FORTIFY_SOURCE -O1 -g`: **all 11 groups pass**, 0 leaks / 0 OOB. The only UBSAN output is the pre-existing `pam.c:49/56/85` `nonnull` diagnostics — the test deliberately passes `pamh=NULL` and libpam declares those parameters `nonnull`; these are test artifacts, not code defects.
- `make test-python`: 60 passed. `make test-shell`: 17 passed.
- Functional suite (`tests/can-actually-be-used`) **not run locally** — it needs `dummy-hcd`/real hardware. Please run it via the `DoMagicOnConfiguredCustomRunner` CI job on the runner before merge.

🤖 This PR was generated with the assistance of an AI coding agent (Claude Opus 4.8).

Relates to the ongoing security audit (#55).

I have read the rules