### PR TITLE
[Security] Remove XML_PARSE_NOENT: it enables entity XXE, not prevents it (issue #367)

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -233,15 +233,14 @@ int pusb_conf_parse(
 		return 0;
 	}
 	// XML_PARSE_NONET blocks all network-URI entity fetches (http://, ftp://). // DevSkim: ignore DS137138 - false positive, this is a comment not a URL
-	// XML_PARSE_NOENT forces eager substitution so that a NONET-blocked entity
-	// reference is expanded to empty content during parsing (where NONET is active)
-	// rather than being left as an unexpanded node that could be fetched later.
-	// file:// entities bypass NONET; exploiting them requires write access to the
-	// root-owned config file, which implies full system compromise already.
-	// Thread-safe per-context entity blocking (xmlCtxtSetExternalEntityLoader)
-	// is available only in libxml2 >= 2.13.
+	// XML_PARSE_NOENT is intentionally NOT set: it enables entity substitution
+	// (including file:// URIs that NONET does not block), which is the opposite
+	// of defence-in-depth. Without NOENT, entity references remain as inert
+	// entity-reference nodes; XPath text() queries do not yield their content.
+	// Thread-safe per-context blocking (xmlCtxtSetExternalEntityLoader) needs
+	// libxml2 >= 2.13 and is not universally available yet.
 	// lgtm[cpp/xxe]
-	if (!(doc = xmlReadFile(file, NULL, XML_PARSE_NONET | XML_PARSE_NOENT)))
+	if (!(doc = xmlReadFile(file, NULL, XML_PARSE_NONET)))
 	{
 		log_error("Unable to parse \"%s\".\n", file);
 		return 0;

--- a/tests/unit/c/conf_test.c
+++ b/tests/unit/c/conf_test.c
@@ -378,13 +378,12 @@ static void test_parse_nonet_blocks_network_entity(void **state)
 	 * The entity reference is placed in the user's <device> element — the
 	 * canonical auth-bypass attack vector. If the entity were resolved,
 	 * it would expand to "real-device" and match the declared device, granting
-	 * access. With XML_PARSE_NONET the http:// load is blocked; the entity
-	 * expands to empty, so no real device is matched and device_list entries
-	 * remain blank (name[0] == '\0').
+	 * access. With XML_PARSE_NONET the http:// load is blocked; without
+	 * XML_PARSE_NOENT entity references are never substituted, so no device
+	 * name appears in the tree and device_list entries remain blank.
 	 *
-	 * Note: file:// entities bypass XML_PARSE_NONET; exploiting them requires
-	 * write access to the root-owned config file (already full system compromise).
-	 * Thread-safe per-context entity blocking needs libxml2 >= 2.13.
+	 * Note: XML_PARSE_NOENT is intentionally absent — it enables entity
+	 * substitution (including file:// URIs) and was the wrong mitigation.
 	 */
 	char tmpfile[] = "/tmp/pamusb_xxe_net_XXXXXX";
 	int fd = mkstemp(tmpfile);
@@ -420,42 +419,6 @@ static void test_parse_nonet_blocks_network_entity(void **state)
 	unlink(tmpfile);
 }
 
-static void test_parse_xml_with_internal_entities_is_accepted(void **state)
-{
-	(void)state;
-	/*
-	 * Positive regression: XML_PARSE_NOENT must not break configs that use
-	 * only safe internal entity declarations.
-	 */
-	char tmpfile[] = "/tmp/pamusb_xxe_internal_XXXXXX";
-	int fd = mkstemp(tmpfile);
-	assert_true(fd >= 0);
-	FILE *f = fdopen(fd, "w");
-	assert_non_null(f);
-	assert_true(fputs("<?xml version=\"1.0\"?>" /* DevSkim: ignore DS154189 */
-		"<!DOCTYPE configuration ["
-		"  <!ENTITY vendor \"TestVendor\">"
-		"]>"
-		"<configuration>"
-		"  <devices>"
-		"    <device id=\"dev1\"><vendor>&vendor;</vendor><model>M</model>"
-		"      <serial>S001</serial><volume_uuid>UUID-1</volume_uuid></device>"
-		"  </devices>"
-		"  <users>"
-		"    <user id=\"testuser\"><device>dev1</device></user>"
-		"  </users>"
-		"  <services><service id=\"login\"></service></services>"
-		"</configuration>", f) != EOF);
-	fclose(f);
-
-	t_pusb_options opts;
-	pusb_conf_init(&opts);
-	assert_int_equal(1, pusb_conf_parse(tmpfile, &opts, "testuser", "login"));
-	assert_int_equal(1, opts.device_count);
-	assert_string_equal("TestVendor", opts.device_list[0].vendor);
-	pusb_conf_free(&opts);
-	unlink(tmpfile);
-}
 
 /* ── per-device option isolation ── */
 
@@ -521,7 +484,6 @@ int main(void)
 		cmocka_unit_test(test_conf_parses_more_than_ten_devices),
 		cmocka_unit_test(test_parse_many_devices_no_false_positive),
 		cmocka_unit_test(test_parse_nonet_blocks_network_entity),
-		cmocka_unit_test(test_parse_xml_with_internal_entities_is_accepted),
 		cmocka_unit_test(test_device_options_not_applied),
 	};
 	return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
## Summary

- Removes `XML_PARSE_NOENT` from the `xmlReadFile()` call in `src/conf.c`
- Corrects the associated comment which described the flag's effect backwards
- Removes `test_parse_xml_with_internal_entities_is_accepted` which was testing the now-absent flag
- Updates the network-entity regression test comment to reflect the correct mechanism

## Why this approach

`XML_PARSE_NOENT` is defined by libxml2 as *"substitute entities"* — it **enables** entity substitution, it does not prevent it. The flag was added under the mistaken belief that it forces NONET-blocked entity references to expand to empty content. That is not how libxml2 works.

The actual effect of the previous `XML_PARSE_NONET | XML_PARSE_NOENT` combination:

| Entity type | NONET | NOENT | Result |
|---|---|---|---|
| `http://`, `ftp://` | Blocks load | n/a | Reference unresolved — safe ✓ |
| `file:///etc/passwd` | Not blocked | Substitutes content into tree | **File content leaks into XPath results** ✗ |

With only `XML_PARSE_NONET` (this PR):
- Network entities are still blocked
- Entity references are **never substituted** into the tree (they remain as inert entity-reference nodes that XPath `text()` queries do not yield)
- `file://` entities are therefore also harmless — even if the entity is declared, its content never appears in the parsed tree

Normal `pamusb.conf` files, as generated by `pamusb-conf`, never contain entity declarations. There is no functional regression for real-world configs.

The practical exploitability of the file:// vector was already low (requires write access to the root-owned config file), but the code was doing the opposite of what was intended and the comment was factually wrong. This PR corrects both.

## How this mistake happened

The original XXE fix in #385 was written by Claude Sonnet 4.6 during the security audit (issue #55). Claude reasoned — incorrectly — that `XML_PARSE_NOENT` would cause NONET-blocked entity references to "expand to empty content" rather than remain as unexpanded nodes. This reasoning is backwards: the flag enables substitution of entities that *are* successfully loaded; it has no bearing on what happens to entities that NONET prevents from loading. Claude then wrote a confident, detailed comment explaining this wrong mental model, added a regression test that appeared to validate the behaviour, and the error went undetected.

The maintainer (@mcdope) shares responsibility here: the PR was merged without catching that the flag description was factually incorrect and directly contradicted by the libxml2 header (`XML_PARSE_NOENT = 1<<1, /* substitute entities */`). A closer review of the flag semantics — or a simple check against the libxml2 docs — would have caught this before it landed. The lesson is that AI-generated security fixes deserve the same adversarial scrutiny as any other security-sensitive change, regardless of how well-justified the accompanying comment looks.

Credit for catching this goes to Nick Wellnhof (ex-libxml2 maintainer), who spotted it in a single sentence: *"You got it backwards. `XML_PARSE_NOENT` enables entity expansion and XXE."*

## Test plan

- [x] `make test` passes (85 tests: 60 Python + 25 shell + C suite)
- [x] `test_parse_nonet_blocks_network_entity` still passes with `XML_PARSE_NONET` alone
- [x] Removed `test_parse_xml_with_internal_entities_is_accepted` (it tested `XML_PARSE_NOENT` behaviour, not a security property)

Refs #367

🤖 This PR was generated with the assistance of Claude Sonnet 4.6

I have read the rules