### PR TITLE
[Enhancement] Maximize deny_remote coverage in functional test suite

### DIFF
--- a/.github/workflows/build-and-test-on-own-server.yml
+++ b/.github/workflows/build-and-test-on-own-server.yml
@@ -96,13 +96,6 @@ jobs:
         TEST_RUNNER_PASS_NEW: ${{ secrets.TEST_RUNNER_PASS_2025 }}
         TEST_RUNNER_PORT_NEW: ${{ secrets.TEST_RUNNER_PORT_NEW }}
       run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "cd ~/pam_usb_$GITHUB_RUN_ID && sudo DEBIAN_FRONTEND=noninteractive apt install --reinstall -yq ../*.deb"
-    - name: disable deny_remote option # ... else the verify test cant be successful if run from a remote host like Github actions runner
-      env:
-        TEST_RUNNER_HOST_NEW: ${{ secrets.TEST_RUNNER_HOST_NEW }}
-        TEST_RUNNER_USER_NEW: ${{ secrets.TEST_RUNNER_USER_NEW }}
-        TEST_RUNNER_PASS_NEW: ${{ secrets.TEST_RUNNER_PASS_2025 }}
-        TEST_RUNNER_PORT_NEW: ${{ secrets.TEST_RUNNER_PORT_NEW }}
-      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "sudo sed -i 's/<defaults>/<defaults><option name=\"deny_remote\">false<\/option>/g' /etc/security/pam_usb.conf"
     # @todo: to include this, we need an uninstall at the end first - currently we require this to be present on the target host
     # - name: setup dummy-hcd module for fake usb stick
     #   run: cd tests/can-actually-be-used && ./setup-dummyhcd.sh
@@ -119,7 +112,7 @@ jobs:
         TEST_RUNNER_USER_NEW: ${{ secrets.TEST_RUNNER_USER_NEW }}
         TEST_RUNNER_PASS_NEW: ${{ secrets.TEST_RUNNER_PASS_2025 }}
         TEST_RUNNER_PORT_NEW: ${{ secrets.TEST_RUNNER_PORT_NEW }}
-      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "cd ~/pam_usb_$GITHUB_RUN_ID/tests/can-actually-be-used && ./run-tests.sh"
+      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "cd ~/pam_usb_$GITHUB_RUN_ID/tests/can-actually-be-used && PAMUSB_CI_MODE=1 ./run-tests.sh"
     - name: cleanup - umount & remove image file, pads, mountpoint
       if: always()
       env:

--- a/tests/can-actually-be-used/run-tests.sh
+++ b/tests/can-actually-be-used/run-tests.sh
@@ -58,6 +58,18 @@ for PUSB_FS_TYPE in vfat ext4 exfat; do
     ./test-conf-adds-device.sh
     ./test-conf-adds-user.sh
     ./test-conf-doesnt-add-user-twice-but-adds-a-second-device.sh
+    ./test-check-deny-remote-ssh.sh
+
+    # Scope the deny_remote bypass to just this user, so the SSH-ancestry
+    # denial path above stays testable while later tests can still call
+    # pamusb-check successfully over the SSH-driven CI runner.
+    if [ "$PAMUSB_CI_MODE" = "1" ]; then
+        WHOAMI=$(whoami)
+        if ! grep -q "<user id=\"$WHOAMI\"><option name=\"deny_remote\">false</option>" /etc/security/pam_usb.conf; then
+            sudo sed -i "s|<user id=\"$WHOAMI\">|<user id=\"$WHOAMI\"><option name=\"deny_remote\">false</option>|" /etc/security/pam_usb.conf
+        fi
+    fi
+
     ./test-check-verify-created-config.sh
     ./test-conf-reset-pads.sh
     ./test-check-recovers-stale-pad-tmp.sh

--- a/tests/can-actually-be-used/test-check-deny-remote-ssh.sh
+++ b/tests/can-actually-be-used/test-check-deny-remote-ssh.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/bash
+#
+# Regression test for local.c: an sshd ancestor process must cause denial.
+# This exercises the parent-process-chain detection in pusb_local_login()
+# (src/local.c), which fires before any device or TTY inspection, so no
+# USB device is required for this test.
+#
+# Unlike XRDP_SESSION, there is no env var to fake an sshd ancestor, so this
+# test only makes sense when actually invoked over SSH (as CI does). We skip
+# gracefully when run locally.
+#
+# We check syslog for the message content because log_error() only writes
+# to stderr when stdin is a TTY (see log.c:pusb_log_output); in CI (non-interactive
+# SSH) stdin is not a TTY, so the message only appears in syslog.
+
+if [ -z "$SSH_CONNECTION" ] && [ -z "$SSH_CLIENT" ]; then
+    echo "Skipping: not running in an SSH session, no sshd ancestor to detect"
+    exit 0
+fi
+
+WHOAMI=$(whoami)
+
+echo -e "Test:\t\t\tpamusb-check denies access when an sshd ancestor is detected"
+if pamusb-check "$WHOAMI" 2>/dev/null; then
+    echo "FAILED: pamusb-check should deny access when invoked from an SSH session"
+    exit 1
+fi
+echo -e "Result:\t\t\tPASSED!"
+
+echo -e "Test:\t\t\tpamusb-check log contains remote access daemon message"
+pamusb-check "$WHOAMI" 2>/dev/null || true
+journalctl -t pam_usb --no-pager -n 20 2>/dev/null | grep -q "One of the parent processes found to be a remote access daemon, denying." && \
+    echo -e "Result:\t\t\tPASSED!" || \
+    { echo "FAILED: expected 'One of the parent processes found to be a remote access daemon, denying.' in syslog"; exit 1; }


### PR DESCRIPTION
## Summary

CI globally disabled `deny_remote` before running any tests (via a workflow step patching `<defaults>` directly), because the functional suite is driven entirely over SSH and `deny_remote` (which defaults to `true`) would otherwise deny every `pamusb-check` call. As a result, the sshd parent-process-chain detection path in `local.c` had zero test coverage — the one feature this CI environment is naturally positioned to exercise (since it always runs over SSH) was the one thing disabled before tests ran.

- Adds `test-check-deny-remote-ssh.sh`, which exercises the sshd-ancestry denial path directly (no device/user setup needed, since the check fires before device inspection). It skips gracefully when not actually run over SSH, since there's no env var to fake an sshd ancestor (unlike `XRDP_SESSION`).
- Replaces the blanket global disable with a bypass scoped to just the current CI user's `<user>` config entry, gated behind a new `PAMUSB_CI_MODE=1` env var passed from the workflow. This keeps `deny_remote` enforced for everything except the handful of tests that need a successful `pamusb-check` call from the SSH-driven runner.
- Removes the old "disable deny_remote option" workflow step entirely.

### Why this approach

Scoping the bypass to the specific user (rather than `<defaults>`) means `deny_remote` stays "on" by default for the whole suite, and only the tests that structurally require a granted auth over SSH get an explicit, narrow opt-out — instead of the feature being untested end-to-end. Tests that build their own temp config from a copy of the live config (`test-check-many-devices.sh`, `test-check-superuser-filtering.sh`) automatically inherit the scoped bypass with no changes needed on their end.

Closes #420

## Test plan

- [x] `bash -n` syntax check on the new/modified shell scripts
- [x] Verified locally that `test-check-deny-remote-ssh.sh` skips gracefully (exit 0) when not run over SSH
- [x] Full `tests/can-actually-be-used/run-tests.sh` run on the dedicated CI runner (real SSH session) confirming: new test denies + logs the expected message, and `test-check-verify-created-config.sh` / `test-check-many-devices.sh` / `test-check-superuser-filtering.sh` still pass under `PAMUSB_CI_MODE=1`
- [x] `make test`

🤖 This PR was generated with the assistance of Claude Code

I have read the rules