### PR TITLE
[Bug] Fix deny_remote coverage gap on QEMU ARM functional test runs

### DIFF
--- a/tests/can-actually-be-used/run-tests-in-qemu.sh
+++ b/tests/can-actually-be-used/run-tests-in-qemu.sh
@@ -438,9 +438,6 @@ for i in $(seq 1 12); do
 done
 [ $SETTLED -eq 1 ] || { echo "Error: VM did not settle after install (postinst timeout)" >&2; exit 1; }
 
-# Tests run inside an SSH session so deny_remote would block authentication
-$SSH_CMD "sudo sed -i 's/<defaults>/<defaults><option name=\"deny_remote\">false<\/option>/g' /etc/security/pam_usb.conf"
-
 $SSH_CMD "mkdir -p /tmp/pam_usb_tests"
 $SCP_CMD -r "$SCRIPT_DIR/." "${TEST_USER}@127.0.0.1:/tmp/pam_usb_tests/"
 
@@ -448,7 +445,7 @@ $SSH_CMD "cd /tmp/pam_usb_tests && ./setup-dummyhcd.sh"
 $SSH_CMD "cd /tmp/pam_usb_tests && ./prepare-mounting.sh"
 
 echo "Running functional test suite in $ARCH VM..."
-$SSH_CMD "cd /tmp/pam_usb_tests && ./run-tests.sh"
+$SSH_CMD "cd /tmp/pam_usb_tests && PAMUSB_CI_MODE=1 ./run-tests.sh"
 
 $SSH_CMD "sudo shutdown -h now" 2>/dev/null || true
 sleep 5


### PR DESCRIPTION
## Summary

Follow-up to #420 (PR #444, merged): that PR replaced the global `deny_remote` disable in `build-and-test-on-own-server.yml` with a scoped per-user bypass gated behind `PAMUSB_CI_MODE=1`, and added `test-check-deny-remote-ssh.sh` to cover the sshd-ancestry denial path.

It missed that `tests/can-actually-be-used/run-tests-in-qemu.sh` — used by the arm64/armhf packaging workflow to run the full functional suite inside a QEMU VM — has its own **independent** copy of the old blanket `deny_remote=false` `<defaults>` patch, and never passed `PAMUSB_CI_MODE=1` when invoking `run-tests.sh`. On that path `deny_remote` stayed globally disabled, so `pamusb-check` never denied and the new test's "expect denial" assertion always failed — i.e. the new test fails on QEMU-based ARM runs.

### Why this approach

Apply the exact same fix already applied to `build-and-test-on-own-server.yml`: drop the blanket global disable and pass `PAMUSB_CI_MODE=1` so the scoped per-user bypass (already implemented in `run-tests.sh`) takes over. Keeps both invocation paths consistent instead of maintaining two different deny_remote-handling strategies.

Refs #420

## Test plan

- [x] `bash -n` syntax check on the modified script
- [x] Diff-reviewed against the equivalent fix already merged for `build-and-test-on-own-server.yml`
- [ ] Full arm64/armhf QEMU functional test run via the packaging workflow, confirming `test-check-deny-remote-ssh.sh` now passes and no other test regresses under `PAMUSB_CI_MODE=1`

🤖 This PR was generated with the assistance of Claude Code

I have read the rules