### PR TITLE
Prepare 0.9.3 release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,23 @@
+* 0.9.3
+  [CI/Tests] Maximize deny_remote functional/QEMU test coverage (#444, #445)
+  [Security] Remove XML_PARSE_NOENT: it enables entity XXE, not prevents it (issue #367) (#442)
+  [Security] Security audit round 8: deny_remote NUL-termination + correctness/UB fixes in xpath.c (#440)
+  [Bug] Recover from orphaned .tmp pad files after interrupted update (#439)
+  [Enhancement] Add pamusb-evdev-helper setgid binary + input group notice in --add-user (#437)
+  [Bug] Fix deny_remote false-deny when user has multiple sessions (#436)
+  [Enhancement] Multi-architecture build (arm64, armhf, i386, m68k, riscv64) + QEMU functional tests (#429)
+  [Bug] Fix make deinstall leaving PAM config behind due to wrong path (#422)
+  [Security] Fixed GHSA-gc6f-5hpq-ghxh (heap OOB read in pusb_get_tty_from_display_server cmdline scan) (#426)
+  [Security] Fixed GHSA-gc4c-v52c-2v34 / GHSA-7583-9cqv-j9rf (deny_remote IPv6 bypass vectors in tmux.c) (#423)
+  [Bug] Fix deny_remote breaking on alphanumeric loginctl session IDs (#418)
+  [Bug] Fix pinentry-pamusb.1.gz not removed on make deinstall (#421)
+  [Security] Fixed GHSA-ffx6-xjp6-x33g (XRDP session bypass via env var manipulation) (#417)
+  [Enhancement] Fix chaotic pam_usb.conf formatting after tool runs (#415)
+  [CI/Tests] Add multi-filesystem functional test coverage (ext4, exFAT) (#409)
+  [Packaging] Sync packaging exclude lists across all build methods (#408)
+  [Enhancement] Add zst-sign Makefile target for Arch package signing
+  [Bug] pamusb-check debug output broken (#404)
+
 * 0.9.2
   [Enhancement] Emit log_error when superuser device filtering removes all devices (#399)
   [Security] Fixed GHSA-rmp6-wfrq-wrrc (xfree() heap memory not cleared before free) (#374)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ At every point in time only the most recent release is supported.
 
 | Version | Supported          |
 |---------| ------------------ |
-| 0.9.2   | ✅                 |
-| < 0.9.2 | ❌                 |
+| 0.9.3   | ✅                 |
+| < 0.9.3 | ❌                 |
 
 ## Reporting a Vulnerability
 

--- a/arch_linux/PKGBUILD_stable
+++ b/arch_linux/PKGBUILD_stable
@@ -2,7 +2,7 @@
 # Contributor: Pekka Helenius <fincer89 [at] hotmail [dot] com>
 
 pkgname=pam_usb
-pkgver=0.9.2
+pkgver=0.9.3
 pkgrel=1
 pkgdesc='Hardware authentication for Linux using ordinary flash media (USB & Card based).'
 arch=($CARCH)
@@ -14,7 +14,7 @@ backup=("etc/security/pam_usb.conf")
 install=pam_usb.install
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/$pkgver.tar.gz"
         "pamusb-agent.service")
-sha256sums=('6ddd263e22dbf0c1b7321bcd257b63b1926e1e4ff2bdc07038d54efabe5ff574'
+sha256sums=('SKIP'
             'f5875f0669b2638f36885c305d719072798b5097b15e6c94a8a852bb896bfc5c')
 
 build() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,26 @@
+libpam-usb (0.9.3) unstable; urgency=high
+
+  * [CI/Tests] Maximize deny_remote functional/QEMU test coverage (#444, #445)
+  * [Security] Remove XML_PARSE_NOENT: it enables entity XXE, not prevents it (issue #367) (#442)
+  * [Security] Security audit round 8: deny_remote NUL-termination + correctness/UB fixes in xpath.c (#440)
+  * [Bug] Recover from orphaned .tmp pad files after interrupted update (#439)
+  * [Enhancement] Add pamusb-evdev-helper setgid binary + input group notice in --add-user (#437)
+  * [Bug] Fix deny_remote false-deny when user has multiple sessions (#436)
+  * [Enhancement] Multi-architecture build (arm64, armhf, i386, m68k, riscv64) + QEMU functional tests (#429)
+  * [Bug] Fix make deinstall leaving PAM config behind due to wrong path (#422)
+  * [Security] Fixed GHSA-gc6f-5hpq-ghxh (heap OOB read in pusb_get_tty_from_display_server cmdline scan) (#426)
+  * [Security] Fixed GHSA-gc4c-v52c-2v34 / GHSA-7583-9cqv-j9rf (deny_remote IPv6 bypass vectors in tmux.c) (#423)
+  * [Bug] Fix deny_remote breaking on alphanumeric loginctl session IDs (#418)
+  * [Bug] Fix pinentry-pamusb.1.gz not removed on make deinstall (#421)
+  * [Security] Fixed GHSA-ffx6-xjp6-x33g (XRDP session bypass via env var manipulation) (#417)
+  * [Enhancement] Fix chaotic pam_usb.conf formatting after tool runs (#415)
+  * [CI/Tests] Add multi-filesystem functional test coverage (ext4, exFAT) (#409)
+  * [Packaging] Sync packaging exclude lists across all build methods (#408)
+  * [Enhancement] Add zst-sign Makefile target for Arch package signing
+  * [Bug] pamusb-check debug output broken (#404)
+
+ -- Tobias Bäumer <tobiasbaeumer@gmail.com>  Thu, 02 Jul 2026 00:00:00 +0200
+
 libpam-usb (0.9.2) unstable; urgency=high
 
   * [Enhancement] Emit log_error when superuser device filtering removes all devices (#399)

--- a/doc/CONFIGURATION
+++ b/doc/CONFIGURATION
@@ -44,7 +44,7 @@ The syntax is the following:
 | `color_log`            | Boolean | `true`              | Enable colored output                                            |
 | `one_time_pad`         | Boolean | `true`              | Enable the use of one time device-associated pad files           |
 | `deny_remote`          | Boolean | `true`              | Deny access from remote host (SSH)                               |
-| `remote_desktop_check` | Boolean | `true`              | Deny access when remote desktop tools detected (TeamViewer etc.) (v0.8.8+) |
+| `remote_desktop_check` | Boolean | `true`              | Deny access when remote desktop tools detected (TeamViewer etc.). Only takes effect when `deny_remote` is `true`. (v0.9.0+) |
 | `superuser`            | Boolean | `false`             | Require a superuser-capable device for this service. Only meaningful on `<service>`. (v0.8.7+) |
 | `probe_timeout`        | Time    | `10s`               | Time to wait for the volume to be detected                       |
 | `pad_expiration`       | Time    | `1h`                | Time between pad file regeneration. Set to `0` to regenerate at every login. |
@@ -57,6 +57,12 @@ The syntax is the following:
 > Examples: `10s`, `5m`, `1h`, `2d`, `3600`.
 
 > **Boolean values** are case-sensitive. Only the exact strings `true` and `false` are accepted.
+
+> **`remote_desktop_check` and `/dev/input` access:** this check needs read access to
+> `/dev/input`. Since v0.9.3 packages install a setgid helper that handles this
+> automatically for non-root invocations (screen lockers, manual `pamusb-check` runs).
+> See [Troubleshooting](Troubleshooting#permission-errors-on-the-virtual-input-device-check-eacces--permission-denied)
+> if you see `EACCES`/"permission denied" in the debug log for this check.
 
 > **Option precedence:** Options defined in later scopes override those in earlier scopes.
 > The order is: `<defaults>` → `<users>` → `<services>`.
@@ -235,6 +241,29 @@ Services can use all options from the [Options](#options) section. The `superuse
 </service>
 ```
 
+### Default `deny_remote` service whitelist
+
+The configuration shipped with pam_usb (`/etc/security/pam_usb.conf`) sets
+`deny_remote=false` for a number of services out of the box:
+
+```
+pamusb-agent, gdm-password, xdm, lxdm, xscreensaver, lightdm, sddm,
+polkit-1, kde, login
+```
+
+These services are whitelisted because they typically run in a context where the
+remote signals pam_usb relies on (notably `PAM_RHOST`) are not set or not
+meaningful — e.g. a local display manager greeter, a local screensaver, or the
+local polkit agent. Leaving `deny_remote` enabled for them would cause false
+denials of legitimate **local** logins.
+
+> **Security note:** This is also why XDMCP and similar remote-display setups need
+> extra care — see the [Security page](https://github.com/mcdope/pam_usb/wiki/Security#warning-about-xdmcp).
+> If a whitelisted display manager is reachable remotely, the `PAM_RHOST` check
+> (which since v0.9.1 always runs regardless of `deny_remote`) and
+> `remote_desktop_check` are your remaining safeguards. You can remove a service
+> from the whitelist by setting `deny_remote=true` for it in your config.
+
 ----------
 
 ## Superuser device restriction
@@ -360,7 +389,7 @@ Device "StudentUSB" excluded for service "sudo" (no superuser attribute).
 
 - Adding more superuser-granted services requires only a new `<service>` entry — no change to device or user configuration.
 - If a user has no device with `superuser="true"` and authenticates against a superuser-marked service, pam_usb denies the request. The fallback PAM module (e.g. `pam_unix`) still runs if configured as `sufficient` rather than `required`.
-- Use `pamusb-conf --add-user=<username> --superuser` to mark the device as superuser-capable at configuration time. The `--superuser` flag sets `superuser="true"` on the `<device>` element automatically (available from v0.8.8).
+- Use `pamusb-conf --add-user=<username> --superuser` to mark the device as superuser-capable at configuration time. The `--superuser` flag sets `superuser="true"` on the `<device>` element automatically (available from v0.9.0).
 
 ----------
 

--- a/doc/SECURITY
+++ b/doc/SECURITY
@@ -6,6 +6,71 @@ Make sure you are aware of how it works and what you combine it with (see other 
 
 Also I want to point it that this is barely audited. I've tried to raise funds for it but there was literally no interest in it seemingly...
 
+# Known CVEs and security advisories
+
+pam_usb has gone through an ongoing security audit. The advisories below have been
+**published** and are **fixed** in the listed release — update to at least that
+version (ideally the latest) to be protected. Full write-ups (impact, affected
+versions, patches, credits) are available on the
+[GitHub Security Advisories page](https://github.com/mcdope/pam_usb/security/advisories).
+
+CVSS scores are v3.1 base scores as recorded on the advisory. Advisories scoring
+below CVSS 4.0 are not assigned a CVE (shown as `—` in the CVE column) and are
+referenced by their GHSA identifier.
+
+> **Note:** Additional advisories from later audit rounds are being prepared and
+> will be published together with the release that fixes them. Per our
+> [responsible disclosure policy](https://github.com/mcdope/pam_usb/blob/master/SECURITY.md),
+> unfixed issues are not detailed publicly until a fix ships.
+
+### Fixed in 0.8.7
+
+| CVE | GHSA | Severity | CVSS | Summary |
+|-----|------|----------|:----:|---------|
+| [CVE-2026-44713](https://github.com/mcdope/pam_usb/security/advisories/GHSA-822m-whrh-vrj8) | GHSA-822m-whrh-vrj8 | High | 8.8 | Command injection via `$TMUX` environment variable leads to RCE as root |
+| [CVE-2026-44712](https://github.com/mcdope/pam_usb/security/advisories/GHSA-jgv5-w6rm-7wxg) | GHSA-jgv5-w6rm-7wxg | High | 8.2 | Shell injection via device UUID and username in `pamusb-conf` / `pamusb-agent` |
+| [CVE-2026-44711](https://github.com/mcdope/pam_usb/security/advisories/GHSA-fjpm-p9pj-mp34) | GHSA-fjpm-p9pj-mp34 | High | 7.9 | Symlink attacks on the pad directory/files enable auth bypass and root file corruption |
+| [CVE-2026-44709](https://github.com/mcdope/pam_usb/security/advisories/GHSA-jxrj-q67x-wr4c) | GHSA-jxrj-q67x-wr4c | High | 7.8 | `PINENTRY_FALLBACK_APP` allows arbitrary command execution; keyring password exposed in process args |
+| [CVE-2026-44710](https://github.com/mcdope/pam_usb/security/advisories/GHSA-j8cq-2gv6-gfwf) | GHSA-j8cq-2gv6-gfwf | Medium | 4.6 | NULL pointer dereference from UDisks device fields causes PAM crash (login DoS) |
+
+### Fixed in 0.9.0
+
+| CVE | GHSA | Severity | CVSS | Summary |
+|-----|------|----------|:----:|---------|
+| [CVE-2026-47269](https://github.com/mcdope/pam_usb/security/advisories/GHSA-jmmj-qhrq-w45g) | GHSA-jmmj-qhrq-w45g | High | 7.4 | `deny_remote` incorrectly classifies IPv4-mapped IPv6 remote connections as local |
+| — | GHSA-7cgr-4c38-59h2 | High | 7.4 | Local authentication check bypass via incorrect process ancestry and session identity parsing |
+| [CVE-2026-47272](https://github.com/mcdope/pam_usb/security/advisories/GHSA-vx6f-rrqr-j87c) | GHSA-vx6f-rrqr-j87c | High | 7.1 | OTP pad authentication bypass via missing system pad check and uninitialized RNG buffer |
+| [CVE-2026-47273](https://github.com/mcdope/pam_usb/security/advisories/GHSA-vfj3-5h5v-6g93) | GHSA-vfj3-5h5v-6g93 | Medium | 6.5 | XPath injection via PAM-supplied identifiers in configuration queries |
+| [CVE-2026-47274](https://github.com/mcdope/pam_usb/security/advisories/GHSA-pp29-w28g-r9h9) | GHSA-pp29-w28g-r9h9 | Medium | 6.3 | Uncontrolled search path in the tools allows privilege escalation via `PATH` manipulation |
+| [CVE-2026-47270](https://github.com/mcdope/pam_usb/security/advisories/GHSA-j3xw-vc43-x7jg) | GHSA-j3xw-vc43-x7jg | Medium | 6.3 | `strtok()` race condition in multi-threaded PAM hosts can corrupt the `deny_remote` result |
+| [CVE-2026-47271](https://github.com/mcdope/pam_usb/security/advisories/GHSA-7rvx-jcc6-7hqq) | GHSA-7rvx-jcc6-7hqq | Medium | 5.1 | OOM guards removed by `-DNDEBUG` cause NULL dereference and auth process crash |
+
+### Fixed in 0.9.1
+
+| CVE | GHSA | Severity | CVSS | Summary |
+|-----|------|----------|:----:|---------|
+| [CVE-2026-48064](https://github.com/mcdope/pam_usb/security/advisories/GHSA-w38v-cw9r-x9p6) | GHSA-w38v-cw9r-x9p6 | High | 8.1 | `PAM_RHOST` check skipped when `deny_remote=false` allows XDMCP authentication bypass |
+| [CVE-2026-48065](https://github.com/mcdope/pam_usb/security/advisories/GHSA-24mw-m2vf-36vp) | GHSA-24mw-m2vf-36vp | Medium | 6.7 | Unchecked integer multiplication before `xmalloc()` allows heap overflow on 32-bit targets |
+| [CVE-2026-48066](https://github.com/mcdope/pam_usb/security/advisories/GHSA-qg76-57wq-mpv6) | GHSA-qg76-57wq-mpv6 | Medium | 5.7 | Thread-unsafe static pointer in `log.c` causes a data race under concurrent PAM auth |
+| [CVE-2026-48792](https://github.com/mcdope/pam_usb/security/advisories/GHSA-pvrg-chgw-x42c) | GHSA-pvrg-chgw-x42c | Medium | 4.4 | `pusb_has_virtual_input_device()` silently discards `EACCES`, disabling remote-desktop detection under non-root execution |
+
+### Fixed in 0.9.2
+
+| CVE | GHSA | Severity | CVSS | Summary |
+|-----|------|----------|:----:|---------|
+| [CVE-2026-48981](https://github.com/mcdope/pam_usb/security/advisories/GHSA-96vv-r4wc-28c2) | GHSA-96vv-r4wc-28c2 | Medium | 6.7 | `xmlReadFile` with default flags permits XXE network entity fetching in `conf.c` |
+| [CVE-2026-48980](https://github.com/mcdope/pam_usb/security/advisories/GHSA-qr83-mf3h-fvqr) | GHSA-qr83-mf3h-fvqr | Medium | 6.3 | `getenv()` in PAM context allows environment variable injection into local-check logic |
+| [CVE-2026-48982](https://github.com/mcdope/pam_usb/security/advisories/GHSA-hxh6-9574-5vp6) | GHSA-hxh6-9574-5vp6 | Medium | 5.8 | Missing `O_EXCL` on pad temp-file creation allows a concurrent update race |
+| [CVE-2026-48983](https://github.com/mcdope/pam_usb/security/advisories/GHSA-4j8q-67fq-3xc3) | GHSA-4j8q-67fq-3xc3 | Medium | 5.8 | TOCTOU race in pad directory creation allows symlink substitution |
+| [CVE-2026-48985](https://github.com/mcdope/pam_usb/security/advisories/GHSA-7j6h-wfc2-mg5q) | GHSA-7j6h-wfc2-mg5q | Medium | 5.5 | NULL dereference crash in `pusb_is_loginctl_local` when `loginctl` returns an empty Remote field |
+| [CVE-2026-48986](https://github.com/mcdope/pam_usb/security/advisories/GHSA-h28h-9hc3-v595) | GHSA-h28h-9hc3-v595 | Medium | 4.7 | Infinite-loop DoS in the process-tree walk when the parent process exits during authentication |
+| [CVE-2026-48984](https://github.com/mcdope/pam_usb/security/advisories/GHSA-rmp6-wfrq-wrrc) | GHSA-rmp6-wfrq-wrrc | Medium | 4.7 | `xfree()` does not call `explicit_bzero` — sensitive cryptographic material may linger in freed heap |
+| — | GHSA-64g7-3jrm-4jc3 | Low | 3.6 | Missing `O_NOFOLLOW` in `evdev.c` allows symlink following when opening device nodes |
+| — | GHSA-vw5x-vxgv-fgxm | Low | 3.3 | `BUFSIZ` truncation in `pusb_get_process_envvar` may cause false-negative TMUX detection |
+| — | GHSA-xgfj-3wm2-gvx8 | Low | 2.5 | `fopen` without `O_CLOEXEC` in `process.c` leaks `/proc` file descriptors into `popen` children |
+| — | GHSA-rfcg-6wgv-77hw | Low | 1.9 | Integer overflow UB in `pusb_xpath_get_time()` via `atoi` and signed multiplication |
+| — | GHSA-chgp-j28w-mx9q | Low | 1.8 | Per-device config `<option>` elements were silently never applied during config parsing |
+
 # Warning about XDMCP
 
 This warning has been **partially mitigated** since 0.9.1 but XDMCP + pam_usb is still not recommended. Read carefully.
@@ -22,7 +87,7 @@ The `remote_desktop_check` option (enabled by default since 0.9.0) provides an a
 
 # Warning about remote desktop tools
 
-Since v0.8.8, pam_usb ships built-in remote desktop detection controlled by the `remote_desktop_check` option (default: `true`). When enabled, authentication is denied if a known remote desktop service is detected as active.
+Since v0.9.0, pam_usb ships built-in remote desktop detection controlled by the `remote_desktop_check` option (default: `true`). When enabled, authentication is denied if a known remote desktop service is detected as active. The check only runs when `deny_remote` is also enabled.
 
 ## What is detected
 
@@ -231,4 +296,4 @@ Device "StudentUSB" excluded for service "sudo" (no superuser attribute).
 - The restriction is configured entirely in `/etc/security/pam_usb.conf` — no PAM stack changes are needed.
 - Adding more superuser-granted services requires only a new `<service>` entry; no change to the device or user configuration is needed.
 - If a user has no device with `superuser="true"` and authenticates against a superuser-marked service, pam_usb denies the request. The fallback PAM module (e.g. `pam_unix`) still runs if configured as `sufficient` rather than `required`.
-- `pamusb-conf` does not yet have a CLI flag for the `superuser` attribute — add it manually to the `<device>` element in the config file after running `pamusb-conf --add-user`. Tracked in [issue #337](https://github.com/mcdope/pam_usb/issues/337).
+- Use `pamusb-conf --add-user=<username> --superuser` to set `superuser="true"` on the `<device>` element automatically (available from v0.9.0). The `--superuser` flag can only be combined with `--add-user`. Alternatively, add the attribute manually to the `<device>` element in the config file.

--- a/doc/SECURITY
+++ b/doc/SECURITY
@@ -71,6 +71,15 @@ referenced by their GHSA identifier.
 | — | GHSA-rfcg-6wgv-77hw | Low | 1.9 | Integer overflow UB in `pusb_xpath_get_time()` via `atoi` and signed multiplication |
 | — | GHSA-chgp-j28w-mx9q | Low | 1.8 | Per-device config `<option>` elements were silently never applied during config parsing |
 
+### Fixed in 0.9.3
+
+| CVE | GHSA | Severity | CVSS | Summary |
+|-----|------|----------|:----:|---------|
+| — | GHSA-gc4c-v52c-2v34 | High | 7.4 | `deny_remote` bypassed by compressed IPv6 addresses (e.g. `::1`, `fe80::1`) in `pusb_tmux_has_remote_clients` |
+| — | GHSA-7583-9cqv-j9rf | High | 7.4 | `deny_remote` bypassed by zone-indexed IPv6 addresses (e.g. `fe80::1%eth0`) in `pusb_tmux_has_remote_clients` |
+| — | GHSA-ffx6-xjp6-x33g | High | 7.1 | `getenv()` in `pusb_local_login` allows the XRDP `deny_remote` block to be bypassed by unsetting `XRDP_SESSION` |
+| — | GHSA-gc6f-5hpq-ghxh | Medium | 4.4 | Heap out-of-bounds read in `pusb_get_tty_from_display_server` when `/proc/<pid>/cmdline` fills the read buffer |
+
 # Warning about XDMCP
 
 This warning has been **partially mitigated** since 0.9.1 but XDMCP + pam_usb is still not recommended. Read carefully.

--- a/doc/TROUBLESHOOTING
+++ b/doc/TROUBLESHOOTING
@@ -249,7 +249,7 @@ Both must clear for authentication to proceed.
 |---|---|
 | **AnyDesk** | Process `anydesk` is running (any connection state) |
 | **VNC** (gnome-remote-desktop, x11vnc, Xvnc) | External ESTABLISHED connection on local TCP port 5900 **and** a matching VNC server process |
-| **RDP** (gnome-remote-desktop) | External ESTABLISHED connection on local TCP port 3389 **and** `gnome-remote-de` process running |
+| **RDP** (gnome-remote-desktop, xrdp) | External ESTABLISHED connection on local TCP port 3389 **and** a matching process (`gnome-remote-de`, `xrdp`) running |
 | **TeamViewer** | Outbound ESTABLISHED connection to remote TCP port 5938 **and** `TeamViewer_Desk` or `teamviewerd` process running |
 
 All checks use `/proc/net/tcp` (IPv4) and `/proc/net/tcp6` (IPv6). Loopback connections (`127.x.x.x`, `::1`) are never counted as external.
@@ -314,6 +314,40 @@ grep ' 1742 ' /proc/net/tcp6
 
 If you see `01` in the state column, TeamViewer has an active relay connection.
 
+#### Permission errors on the virtual input device check (`EACCES` / "permission denied")
+
+The virtual input device check needs read access to `/dev/input`, which is normally
+restricted to root and members of the `input` group. Since v0.9.3, packages install a
+setgid helper binary, `/usr/lib/pam_usb/pamusb-evdev-helper` (owned `root:input`, setgid
+bit set), so the check works for non-root invocations — e.g. screen lockers
+(i3lock, swaylock, gnome-screensaver) or a manually run `pamusb-check` — without any
+group membership changes. This is automatic for package installs and for `make install`
+when the `input` group exists on the system; no action is required.
+
+If you see a debug line like:
+
+```
+Checking for virtual input devices...
+Failed to open /dev/input/eventX: Permission denied
+```
+
+it means the helper is missing or not installed with the correct setgid permissions
+(e.g. a manual install without the `input` group present at install time, or a custom
+`PREFIX` build). Re-running `make install` after creating the `input` group, or
+reinstalling the package, will pick up the setgid bit.
+
+As a manual fallback (only if the helper cannot be used), add the user to the `input`
+group:
+
+```sh
+sudo usermod -aG input <username>
+```
+
+**Warning:** membership in the `input` group grants read access to *all* input devices,
+including keyboards — effectively keylogger-level access for every process the user
+runs. Only use this on trusted, single-user systems, and prefer the setgid helper
+wherever possible. See `man pamusb-conf` (NOTES section) for details.
+
 #### Diagnosing a deny
 
 Enable debug logging in `pam_usb.conf`:
@@ -336,7 +370,7 @@ Virtual input device detected (possible remote desktop tool), denying.
 ```
 
 ```
-XRDP session detected, denying.
+XRDP session detected (<reason>), denying.
 ```
 
 The debug output will name the exact check that fired.

--- a/fedora/SPECS/pam_usb.spec
+++ b/fedora/SPECS/pam_usb.spec
@@ -1,7 +1,7 @@
 %define _topdir         /usr/local/src/pam_usb/fedora
 %define name            pam_usb 
 %define release         1
-%define version         0.9.2
+%define version         0.9.3
 %define buildroot       %{_topdir}/%{name}‑%{version}‑root
 
 BuildRoot: %{buildroot}
@@ -64,6 +64,26 @@ rm -rf %{buildroot}/usr/share/pam-configs
 %doc %attr(0644,root,root) /usr/share/doc/pam_usb/TROUBLESHOOTING
 
 %changelog
+
+* Thu Jul 02 2026 Tobias Bäumer <tobiasbaeumer@gmail.com> - 0.9.3
+- [CI/Tests] Maximize deny_remote functional/QEMU test coverage (#444, #445)
+- [Security] Remove XML_PARSE_NOENT: it enables entity XXE, not prevents it (issue #367) (#442)
+- [Security] Security audit round 8: deny_remote NUL-termination + correctness/UB fixes in xpath.c (#440)
+- [Bug] Recover from orphaned .tmp pad files after interrupted update (#439)
+- [Enhancement] Add pamusb-evdev-helper setgid binary + input group notice in --add-user (#437)
+- [Bug] Fix deny_remote false-deny when user has multiple sessions (#436)
+- [Enhancement] Multi-architecture build (arm64, armhf, i386, m68k, riscv64) + QEMU functional tests (#429)
+- [Bug] Fix make deinstall leaving PAM config behind due to wrong path (#422)
+- [Security] Fixed GHSA-gc6f-5hpq-ghxh (heap OOB read in pusb_get_tty_from_display_server cmdline scan) (#426)
+- [Security] Fixed GHSA-gc4c-v52c-2v34 / GHSA-7583-9cqv-j9rf (deny_remote IPv6 bypass vectors in tmux.c) (#423)
+- [Bug] Fix deny_remote breaking on alphanumeric loginctl session IDs (#418)
+- [Bug] Fix pinentry-pamusb.1.gz not removed on make deinstall (#421)
+- [Security] Fixed GHSA-ffx6-xjp6-x33g (XRDP session bypass via env var manipulation) (#417)
+- [Enhancement] Fix chaotic pam_usb.conf formatting after tool runs (#415)
+- [CI/Tests] Add multi-filesystem functional test coverage (ext4, exFAT) (#409)
+- [Packaging] Sync packaging exclude lists across all build methods (#408)
+- [Enhancement] Add zst-sign Makefile target for Arch package signing
+- [Bug] pamusb-check debug output broken (#404)
 
 * Sat May 23 2026 Tobias Bäumer <tobiasbaeumer@gmail.com> - 0.9.2
 - [Enhancement] Emit log_error when superuser device filtering removes all devices (#399)

--- a/src/version.h
+++ b/src/version.h
@@ -18,6 +18,6 @@
 #ifndef PUSB_VERSION_H_
 # define PUSB_VERSION_H_
 
-# define PUSB_VERSION "0.9.2"
+# define PUSB_VERSION "0.9.3"
 
 #endif /* !PUSB_VERSION_H_ */

--- a/tools/pamusb-conf
+++ b/tools/pamusb-conf
@@ -465,7 +465,7 @@ def resetPads():
 	sys.exit(0)
 
 def usage():
-	print('Version 0.9.2')
+	print('Version 0.9.3')
 	print('Usage: %s [--help] [--verbose] [--yes] [--config=path] [--reset-pads=username]' % os.path.basename(__file__))
 	print('                [[--add-user=name [--superuser]] | [--add-device=name [[--device=number] [--volume=number]]]]')
 	sys.exit(1)


### PR DESCRIPTION
## Summary

- Bumps version to 0.9.3 across all relevant files (`version.h`, `pamusb-conf`, changelogs, packaging)
- Updates `SECURITY.md` to list 0.9.3 as the supported version
- Adds `ChangeLog` / Debian / Fedora / Arch entries covering all 18 changes since 0.9.2
- Arch `PKGBUILD_stable` sha256sum set to `SKIP` pending the tag (same pattern as the 0.9.2 prep)
- Publishes the 4 draft GHSAs for fixes shipping in this release (`GHSA-gc4c-v52c-2v34`, `GHSA-7583-9cqv-j9rf`, `GHSA-ffx6-xjp6-x33g`, `GHSA-gc6f-5hpq-ghxh`) with `patched_versions = 0.9.3` and CVE requests filed; not part of this diff (done via the GitHub API) but relevant context for review
- Updates wiki docs: documents the `pamusb-evdev-helper` setgid mechanism / `input` group `EACCES` fallback (was in the `pamusb-conf` manpage but missing from the wiki), adds the "Fixed in 0.9.3" advisory table
- Syncs `doc/CONFIGURATION`, `doc/SECURITY`, `doc/TROUBLESHOOTING` from the wiki via `make update-other-docs` (two passes, since the advisory table was added after the first sync)

## Why this approach

Standard release prep: version bump and changelog entries are atomic in a single commit for a clean, bisectable history. The `make update-other-docs` syncs are separate commits since that target requires a clean tree and commits on its own. Manpages were checked against all 18 changes and need no updates — the one behavior-affecting change (`pamusb-evdev-helper`, #437) already documented its manpage in the same PR.

🤖 This PR was generated with the assistance of Claude Sonnet 5

I have read the rules