### PR TITLE
CI: nightly build hygiene + fix leftover runner directories

### DIFF
--- a/.github/workflows/cleanup-stale-runner-dirs.yml
+++ b/.github/workflows/cleanup-stale-runner-dirs.yml
@@ -1,0 +1,25 @@
+name: Cleanup stale runner directories
+
+on:
+  schedule:
+  - cron: '30 2 * * *'
+  workflow_dispatch:
+
+jobs:
+
+  CleanupStaleDirs:
+
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Install sshpass on Github runner
+      run: sudo apt install sshpass
+    - name: FURTHER STEPS EXECUTED ON CONFIGURED RUNNER
+      run: exit 0
+    - name: Sweep orphaned pam_usb_* directories older than 3h
+      env:
+        TEST_RUNNER_HOST_NEW: ${{ secrets.TEST_RUNNER_HOST_NEW }}
+        TEST_RUNNER_USER_NEW: ${{ secrets.TEST_RUNNER_USER_NEW }}
+        TEST_RUNNER_PASS_NEW: ${{ secrets.TEST_RUNNER_PASS_2025 }}
+        TEST_RUNNER_PORT_NEW: ${{ secrets.TEST_RUNNER_PORT_NEW }}
+      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "find ~ -maxdepth 1 -type d -regex '.*/pam_usb_.*[0-9]$' -mmin +180 -printf '%p\n' -exec sudo rm -rf {} +"

--- a/.github/workflows/nightly-build-on-own-server.yml
+++ b/.github/workflows/nightly-build-on-own-server.yml
@@ -1,4 +1,4 @@
-name: Nightly builds (tar.gz, deb, rpm, zst)
+name: Nightly builds (deb, rpm, zst)
 
 on:
   schedule:
@@ -52,13 +52,6 @@ jobs:
         TEST_RUNNER_PORT_NEW: ${{ secrets.TEST_RUNNER_PORT_NEW }}
         REF_TO_CHECKOUT: ${{ github.head_ref }}
       run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -tt -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "sudo rm -rf ~/pam_usb_nightly_$GITHUB_RUN_ID && git clone https://github.com/mcdope/pam_usb.git ~/pam_usb_nightly_$GITHUB_RUN_ID && cd ~/pam_usb_nightly_$GITHUB_RUN_ID && git switch -f $REF_TO_CHECKOUT || git switch -f master && git pull"
-    - name: Build .tar.gz source package
-      env:
-        TEST_RUNNER_HOST_NEW: ${{ secrets.TEST_RUNNER_HOST_NEW }}
-        TEST_RUNNER_USER_NEW: ${{ secrets.TEST_RUNNER_USER_NEW }}
-        TEST_RUNNER_PASS_NEW: ${{ secrets.TEST_RUNNER_PASS_2025 }}
-        TEST_RUNNER_PORT_NEW: ${{ secrets.TEST_RUNNER_PORT_NEW }}
-      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "cd ~/pam_usb_nightly_$GITHUB_RUN_ID && make sourcegz"
     - name: Generate Debian build environment
       env:
         TEST_RUNNER_HOST_NEW: ${{ secrets.TEST_RUNNER_HOST_NEW }}
@@ -168,7 +161,7 @@ jobs:
       run: |
         DATE=$(date +%Y%m%d)
         rm -f .build/pam_usb-git-debug*
-        for f in .build/*.deb .build/*.rpm .build/*.zst .build/*.gz; do
+        for f in .build/*.deb .build/*.rpm .build/*.zst; do
           [ -f "$f" ] && mv "$f" ".build/pam_usb-nightly-${DATE}-$(basename $f)"
         done
     - name: Upload nightly packages
@@ -178,7 +171,6 @@ jobs:
         tag: nightly
         token: ${{ secrets.GITHUB_TOKEN }}
         files: |
-          ./.build/*.gz
           ./.build/*.deb
           ./.build/*.rpm
           ./.build/*.zst

--- a/.github/workflows/nightly-build-on-own-server.yml
+++ b/.github/workflows/nightly-build-on-own-server.yml
@@ -7,8 +7,36 @@ on:
 
 jobs:
 
+  CheckForChanges:
+
+    runs-on: ubuntu-22.04
+    outputs:
+      has_changes: ${{ steps.check.outputs.has_changes }}
+
+    steps:
+    - name: Compare master HEAD against last nightly build
+      id: check
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        HEAD_SHA=$(git ls-remote https://github.com/${{ github.repository }}.git refs/heads/master | cut -f1)
+        NIGHTLY_SHA=$(gh api repos/${{ github.repository }}/git/refs/tags/nightly --jq '.object.sha' 2>/dev/null || echo "")
+        echo "master HEAD: $HEAD_SHA"
+        echo "last nightly build: $NIGHTLY_SHA"
+        if [ "$GITHUB_EVENT_NAME" != "schedule" ]; then
+          echo "Manually triggered run, building regardless of changes."
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+        elif [ -n "$NIGHTLY_SHA" ] && [ "$HEAD_SHA" = "$NIGHTLY_SHA" ]; then
+          echo "No new commits since last nightly build, skipping."
+          echo "has_changes=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+        fi
+
   GenerateNightly:
 
+    needs: CheckForChanges
+    if: needs.CheckForChanges.outputs.has_changes == 'true'
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/package-with-docker-on-own-server.yml
+++ b/.github/workflows/package-with-docker-on-own-server.yml
@@ -220,7 +220,7 @@ jobs:
         TEST_RUNNER_USER_NEW: ${{ secrets.TEST_RUNNER_USER_NEW }}
         TEST_RUNNER_PASS_NEW: ${{ secrets.TEST_RUNNER_PASS_2025 }}
         TEST_RUNNER_PORT_NEW: ${{ secrets.TEST_RUNNER_PORT_NEW }}
-      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -tt -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "docker image prune -f || true"
+      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -tt -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "if [ \"$GITHUB_EVENT_NAME\" != push ]; then sudo rm -rf ~/pam_usb_deb_arm64_$GITHUB_RUN_ID; fi; docker image prune -f || true"
 
 
   Debian-armhf:
@@ -276,7 +276,7 @@ jobs:
         TEST_RUNNER_USER_NEW: ${{ secrets.TEST_RUNNER_USER_NEW }}
         TEST_RUNNER_PASS_NEW: ${{ secrets.TEST_RUNNER_PASS_2025 }}
         TEST_RUNNER_PORT_NEW: ${{ secrets.TEST_RUNNER_PORT_NEW }}
-      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -tt -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "docker image prune -f || true"
+      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -tt -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "if [ \"$GITHUB_EVENT_NAME\" != push ]; then sudo rm -rf ~/pam_usb_deb_armhf_$GITHUB_RUN_ID; fi; docker image prune -f || true"
 
 
   Debian-i386:
@@ -556,7 +556,7 @@ jobs:
         TEST_RUNNER_USER_NEW: ${{ secrets.TEST_RUNNER_USER_NEW }}
         TEST_RUNNER_PASS_NEW: ${{ secrets.TEST_RUNNER_PASS_2025 }}
         TEST_RUNNER_PORT_NEW: ${{ secrets.TEST_RUNNER_PORT_NEW }}
-      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -tt -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "docker image prune -f || true"
+      run: sshpass -p "$TEST_RUNNER_PASS_NEW" ssh -tt -o StrictHostKeyChecking=no -p $TEST_RUNNER_PORT_NEW $TEST_RUNNER_USER_NEW@$TEST_RUNNER_HOST_NEW "sudo rm -rf ~/pam_usb_deb_riscv64_$GITHUB_RUN_ID; docker image prune -f || true"
 
 
   FunctionalTest-arm64:


### PR DESCRIPTION
## Summary
- Nightly build workflow now skips the build entirely when master hasn't advanced since the last nightly tag, instead of rebuilding/republishing identical packages every night regardless of changes.
- Drops the redundant `.tar.gz` source package from nightly builds, since GitHub already auto-generates source tarballs for every tag it publishes to (including `nightly`).
- Fixes three leftover-directory bugs on the self-hosted build runner: `Debian-riscv64`'s Cleanup step never actually removed its checkout directory (leaked on every run), and `Debian-arm64`/`Debian-armhf` deferred cleanup to downstream `FunctionalTest-*` jobs that only run on `push`, so every `pull_request` run left those directories behind permanently.
- Adds a new scheduled workflow that sweeps the runner for any orphaned `pam_usb_*<digits>` directories older than 3 hours, as a safety net against future cleanup-step bugs of the same shape (a similar gap in a now-deleted workflow is why the runner had accumulated ~800MB/165 directories going back to May, since manually cleared as a one-time sweep).

## Why this approach
- The nightly skip-gate compares master's HEAD against the commit the `nightly` tag currently points to (via the GitHub API), rather than anything more complex, since that's exactly what "has anything changed since last nightly" means operationally.
- For arm64/armhf, self-cleaning only on non-`push` events (rather than always self-cleaning, or making `FunctionalTest-*` unconditional) was chosen specifically to preserve the deliberate push-path optimization where those jobs reuse the already-built `.deb` instead of rebuilding it.
- The sweep uses an *include* pattern (`pam_usb_*` ending in a digit) rather than an exclude-list, so it automatically stays safe against the hand-maintained `pam_usb_reprovision` checkout and the persistent `pam_usb` clone without needing to know about them explicitly.

## Test plan
- [x] YAML validated for all modified/added workflow files
- [x] Verified via SSH that `Debian-riscv64`'s directory is removed after a build
- [x] Verified the sweep regex against synthetic test directories matching every current/historical naming pattern, confirming it excludes `pam_usb_reprovision` and the bare `pam_usb` clone
- [x] Ran the one-time historical sweep on the runner (165 dirs / 799M reclaimed), confirmed 0 remaining and both excluded directories untouched
- [ ] Live verification of the arm64/armhf push-path `.deb` reuse still working (`FunctionalTest-arm64`/`FunctionalTest-armhf` finding and reusing the existing `.deb` rather than rebuilding) requires a `push`-triggered run after merge

🤖 This PR was generated with the assistance of Claude Code (Sonnet 5).